### PR TITLE
Outline

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -573,7 +573,7 @@ impl Database {
     /// Dump the outline of this database.
     fn print_outline_node(&mut self, node: &OutlineNode, indent: usize) {
         // let indent = (node.level as usize) * 3
-        println!("{:indent$} {:?}", "", node.level, indent = indent);
+        println!("{:indent$} {:?} {:?}", "", node.level, node.get_name(), indent = indent);
         for child in node.children.iter() {
             self.print_outline_node(&child, indent + 1);
         }        

--- a/src/database.rs
+++ b/src/database.rs
@@ -102,6 +102,8 @@ use diag::DiagnosticClass;
 use diag::Notation;
 use export;
 use nameck::Nameset;
+use outline;
+use outline::OutlineNode;
 use parser::StatementRef;
 use scopeck;
 use scopeck::ScopeResult;
@@ -136,6 +138,8 @@ pub struct DbOptions {
     /// `parser::guess_buffer_name`) of segments which are recalculated in each
     /// pass.
     pub trace_recalc: bool,
+    /// True to record database outline with parts, chapters, and sections.
+    pub outline: bool,
     /// True to record detailed usage data needed for incremental operation.
     ///
     /// This will slow down the initial analysis, so don't set it if you won't
@@ -353,6 +357,7 @@ pub struct Database {
     scopes: Option<Arc<ScopeResult>>,
     prev_verify: Option<Arc<VerifyResult>>,
     verify: Option<Arc<VerifyResult>>,
+    outline: Option<OutlineNode>,
 }
 
 fn time<R, F: FnOnce() -> R>(opts: &DbOptions, name: &str, f: F) -> R {
@@ -375,6 +380,7 @@ impl Drop for Database {
             self.prev_nameset = None;
             self.nameset = None;
             self.segments = None;
+            self.outline = None;
         });
     }
 }
@@ -393,6 +399,7 @@ impl Database {
             nameset: None,
             scopes: None,
             verify: None,
+            outline: None,
             prev_nameset: None,
             prev_scopes: None,
             prev_verify: None,
@@ -434,6 +441,7 @@ impl Database {
             self.nameset = None;
             self.scopes = None;
             self.verify = None;
+            self.outline = None;
         });
     }
 
@@ -516,6 +524,18 @@ impl Database {
         self.verify.as_ref().unwrap()
     }
 
+    /// Returns the root node of the outline
+    pub fn outline_result(&mut self) -> &OutlineNode {
+        if self.outline.is_none() {
+            time(&self.options.clone(), "outline", || {
+                let parse = self.parse_result().clone();
+                self.outline = Some(OutlineNode::default());
+                outline::build_outline(&mut self.outline.as_mut().unwrap(), &parse);
+            })
+        }
+        self.outline.as_ref().unwrap()
+    }
+
     /// Get a statement by label.
     pub fn statement(&mut self, name: &str) -> Option<StatementRef> {
         match self.name_result().lookup_label(name.as_bytes()) {
@@ -540,6 +560,23 @@ impl Database {
                 .and_then(|mut file| export::export_mmp(&parse, &name, &scope, sref, &mut file))
                 .unwrap()
         })
+    }
+
+    /// Dump the outline of this database.
+    pub fn print_outline(&mut self) {
+        time(&self.options.clone(), "print_outline", || {
+            let root_node = self.outline_result().clone();
+            self.print_outline_node(&root_node, 0);
+        })
+    }
+
+    /// Dump the outline of this database.
+    fn print_outline_node(&mut self, node: &OutlineNode, indent: usize) {
+        // let indent = (node.level as usize) * 3
+        println!("{:indent$} {:?}", "", node.level, indent = indent);
+        for child in node.children.iter() {
+            self.print_outline_node(&child, indent + 1);
+        }        
     }
 
     /// Runs one or more passes and collects all errors they generate.

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ pub mod diag;
 pub mod export;
 pub mod line_cache;
 pub mod nameck;
+pub mod outline;
 pub mod parser;
 pub mod proof;
 pub mod scopeck;
@@ -55,6 +56,7 @@ fn main() {
             .long("split"))
         .arg(Arg::with_name("timing").help("Print milliseconds after each stage").long("timing"))
         .arg(Arg::with_name("verify").help("Check proof validity").long("verify").short("v"))
+        .arg(Arg::with_name("outline").help("Show database outline").long("outline").short("o"))
         .arg(Arg::with_name("trace-recalc")
             .help("Print segments as they are recalculated")
             .long("trace-recalc"))
@@ -84,6 +86,7 @@ fn main() {
     let mut options = DbOptions::default();
     options.autosplit = matches.is_present("split");
     options.timing = matches.is_present("timing");
+    options.outline = matches.is_present("outline");
     options.trace_recalc = matches.is_present("trace-recalc");
     options.incremental = matches.is_present("repeat");
     options.jobs = usize::from_str(matches.value_of("jobs").unwrap_or("1"))
@@ -116,6 +119,10 @@ fn main() {
         let mut lc = LineCache::default();
         for notation in db.diag_notations(types) {
             print_annotation(&mut lc, notation);
+        }
+
+        if matches.is_present("outline") {
+            db.print_outline();
         }
 
         if let Some(exps) = matches.values_of_lossy("export") {

--- a/src/outline.rs
+++ b/src/outline.rs
@@ -1,0 +1,82 @@
+//! The database outline.
+//!
+//! This is an analysis pass and should not be invoked directly; it is intended
+//! to be instantiated through `Database`.  It is not considered a stable API,
+//! although a stable wrapper may be added in `Database`.
+
+use parser::HeadingLevel;
+use parser::HeadingDef;
+use parser::Segment;
+use parser::SegmentId;
+use parser::SegmentRef;
+use parser::StatementRef;
+use parser::StatementAddress;
+use segment_set::SegmentSet;
+use std::sync::Arc;
+
+#[derive(Debug,Default,Clone)]
+pub struct OutlineNode {
+    /// Level of this outline
+    pub level: HeadingLevel,
+    /// Statement address
+    pub stmt_address: StatementAddress,
+    /// A list of children subsections
+    pub children: Vec<OutlineNode>,
+}
+
+impl OutlineNode {
+    /// Build the root node for a database
+    fn root_node(segments: &Vec<SegmentRef>) -> Self {
+        OutlineNode {
+            level: HeadingLevel::Database,
+            stmt_address: StatementAddress::new(segments[0].id, 0),
+            children: vec![],
+        }
+    }
+
+    /// Build an outline node, with a generic statement address, from a HeadingDef, which is specific to a segment
+    fn from_heading_def(heading: &HeadingDef, segment_id: SegmentId) -> Self {
+        OutlineNode {
+            level: heading.level,
+            stmt_address: StatementAddress::new(segment_id, heading.index),
+            children: vec![],
+        }
+    }
+
+    /// Add a child to this node, or to the correct sub-node
+    fn add_child(&mut self, child: Self) {
+        assert!(child.level > self.level, "Cannot add subsection of higher level!");
+        match self.children.last_mut() {
+            None => {
+                // this is our first child
+                self.children.push(child);
+            },
+            Some(mut last_child) => {
+                // Append to our last child
+                if child.level > last_child.level {
+                    last_child.add_child(child);
+                } else {
+                    self.children.push(child);
+                }
+            },
+        }
+    }
+
+	// TODO - Return the actual name of the heading
+    
+    // TODO - it would be nice to also have a method returning the heading chapter comment, if there is any.
+}
+
+/// Builds the overall outline from the different segments
+pub fn build_outline<'a>(node: &mut OutlineNode, sset: &'a Arc<SegmentSet>) {
+    let segments = sset.segments();
+    assert!(segments.len() > 0,"Parse returned no segment!");
+    *node = OutlineNode::root_node(&segments);
+
+    for vsr in segments.iter() {
+        for heading in &vsr.segment.outline {
+            let new_node = OutlineNode::from_heading_def(heading, vsr.id);
+            node.add_child(new_node);
+        }
+    }
+}

--- a/src/outline.rs
+++ b/src/outline.rs
@@ -4,79 +4,88 @@
 //! to be instantiated through `Database`.  It is not considered a stable API,
 //! although a stable wrapper may be added in `Database`.
 
+use parser::as_str;
+use parser::copy_token;
+use parser::Token;
 use parser::HeadingLevel;
 use parser::HeadingDef;
-use parser::Segment;
 use parser::SegmentId;
 use parser::SegmentRef;
-use parser::StatementRef;
 use parser::StatementAddress;
 use segment_set::SegmentSet;
 use std::sync::Arc;
 
 #[derive(Debug,Default,Clone)]
+/// A node of a database outline
 pub struct OutlineNode {
-    /// Level of this outline
-    pub level: HeadingLevel,
-    /// Statement address
-    pub stmt_address: StatementAddress,
-    /// A list of children subsections
-    pub children: Vec<OutlineNode>,
+	/// Name of this outline
+	pub name: Token,
+	/// Level of this outline
+	pub level: HeadingLevel,
+	/// Statement address
+	pub stmt_address: StatementAddress,
+	/// A list of children subsections
+	pub children: Vec<OutlineNode>,
 }
 
 impl OutlineNode {
-    /// Build the root node for a database
-    fn root_node(segments: &Vec<SegmentRef>) -> Self {
-        OutlineNode {
-            level: HeadingLevel::Database,
-            stmt_address: StatementAddress::new(segments[0].id, 0),
-            children: vec![],
-        }
-    }
+	/// Build the root node for a database
+	fn root_node(segments: &Vec<SegmentRef>) -> Self {
+		OutlineNode {
+			name: copy_token("Database".as_bytes()),
+			level: HeadingLevel::Database,
+			stmt_address: StatementAddress::new(segments[0].id, 0),
+			children: vec![],
+		}
+	}
 
-    /// Build an outline node, with a generic statement address, from a HeadingDef, which is specific to a segment
-    fn from_heading_def(heading: &HeadingDef, segment_id: SegmentId) -> Self {
-        OutlineNode {
-            level: heading.level,
-            stmt_address: StatementAddress::new(segment_id, heading.index),
-            children: vec![],
-        }
-    }
+	/// Build an outline node, with a generic statement address, from a HeadingDef, which is specific to a segment
+	fn from_heading_def(heading: &HeadingDef, segment_id: SegmentId) -> Self {
+		OutlineNode {
+			name: heading.name.clone(),
+			level: heading.level,
+			stmt_address: StatementAddress::new(segment_id, heading.index),
+			children: vec![],
+		}
+	}
 
-    /// Add a child to this node, or to the correct sub-node
-    fn add_child(&mut self, child: Self) {
-        assert!(child.level > self.level, "Cannot add subsection of higher level!");
-        match self.children.last_mut() {
-            None => {
-                // this is our first child
-                self.children.push(child);
-            },
-            Some(mut last_child) => {
-                // Append to our last child
-                if child.level > last_child.level {
-                    last_child.add_child(child);
-                } else {
-                    self.children.push(child);
-                }
-            },
-        }
-    }
-
-	// TODO - Return the actual name of the heading
-    
-    // TODO - it would be nice to also have a method returning the heading chapter comment, if there is any.
+	/// Add a child to this node, or to the correct sub-node
+	fn add_child(&mut self, child: Self) {
+		assert!(child.level > self.level, "Cannot add subsection of higher level!");
+		match self.children.last_mut() {
+			None => {
+				// this is our first child
+				self.children.push(child);
+			},
+			Some(last_child) => {
+				// Append to our last child
+				if child.level > last_child.level {
+					last_child.add_child(child);
+				} else {
+					self.children.push(child);
+				}
+			},
+		}
+	}
+	
+	/// Returns the name of that node, i.e. the heading title
+	pub fn get_name(&self) -> &str {
+		as_str(&self.name)
+	}
+	
+	// TODO - it would be nice to also have a method returning the heading chapter comment, if there is any.
 }
 
 /// Builds the overall outline from the different segments
 pub fn build_outline<'a>(node: &mut OutlineNode, sset: &'a Arc<SegmentSet>) {
-    let segments = sset.segments();
-    assert!(segments.len() > 0,"Parse returned no segment!");
-    *node = OutlineNode::root_node(&segments);
+	let segments = sset.segments();
+	assert!(segments.len() > 0,"Parse returned no segment!");
+	*node = OutlineNode::root_node(&segments);
 
     for vsr in segments.iter() {
-        for heading in &vsr.segment.outline {
-            let new_node = OutlineNode::from_heading_def(heading, vsr.id);
-            node.add_child(new_node);
-        }
-    }
+		for heading in &vsr.segment.outline {
+			let new_node = OutlineNode::from_heading_def(heading, vsr.id);
+			node.add_child(new_node);
+		}
+	}
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -400,6 +400,15 @@ pub struct LocalVarDef {
     pub ordinal: TokenIndex,
 }
 
+/// Extracted information for outline heading statements.
+#[derive(Debug)]
+pub struct HeadingDef {
+    /// Local inder of the heading statement.
+    pub index: StatementIndex,
+    /// Level of this outline
+    pub level: HeadingLevel,
+}
+
 /// A parsed segment, containing parsed statement data and some extractions.
 ///
 /// This is the main result of the parse which is provided to `segment_set`,
@@ -436,6 +445,8 @@ pub struct Segment {
     pub labels: Vec<LabelDef>,
     /// Global `$f` statements extracted for nameck.
     pub floats: Vec<FloatDef>,
+    /// Top-level headings extracted for outline
+    pub outline: Vec<HeadingDef>,
 }
 
 /// A pointer to a segment which knows its identity.
@@ -504,6 +515,8 @@ pub enum StatementType {
     /// A comment which starts with a `$t` token and must be interpreted
     /// specially by the HTML generator.
     TypesettingComment,
+    /// A comment corresponding to the head of a chapter or section in the outline
+    HeadingComment(HeadingLevel),
     /// A `$[` directive; we process these as statements, and disallow them
     /// inside other statements, which violates the published Metamath spec but
     /// is allowed behavior as an erratum.
@@ -861,12 +874,33 @@ fn is_mm_space(byte: u8) -> bool {
     byte <= 32 && is_mm_space_c0(byte)
 }
 
-// TODO: add outline comment detection
+#[derive(Debug,Eq,PartialEq,Ord,PartialOrd,Copy,Clone)]
+/// The different types of heading markers, as defined in the Metamath book, section 4.4.1
+pub enum HeadingLevel {
+    /// Virtual top-level heading, used as a root node
+    Database,
+    /// Major part
+    MajorPart,
+    /// Section
+    Section,
+    /// Subsection
+    SubSection,
+    /// Subsubsection
+    SubSubSection,
+}
+
+impl Default for HeadingLevel {
+    fn default() -> Self {
+        HeadingLevel::Database
+    }
+}
+
 #[derive(Eq,PartialEq,Copy,Clone)]
 enum CommentType {
     Normal,
     Typesetting,
     Extra,
+    Heading(HeadingLevel),
 }
 
 impl<'a> Scanner<'a> {
@@ -943,8 +977,7 @@ impl<'a> Scanner<'a> {
     /// Assuming that a `$(` token has just been read, read and skip a comment.
     ///
     /// If the comment appears to be special, notice that.  This currently
-    /// detects `$j` and `$t` comments, it will later be responsible for
-    /// detecting outline comments.
+    /// detects `$j`, `$t` comments, and outline comments.
     fn get_comment(&mut self, opener: Span, mid_statement: bool) -> CommentType {
         let mut ctype = CommentType::Normal;
         let mut first = true;
@@ -976,8 +1009,17 @@ impl<'a> Scanner<'a> {
                 if tok_str.contains("$(") {
                     self.diag(Diagnostic::NestedComment(tok, opener));
                 }
+            } else if tok_ref.len() >= 4 {
+                if tok_ref[0..4] == b"####"[0..4] {
+                    ctype = CommentType::Heading(HeadingLevel::MajorPart,);
+                } else if tok_ref[0..4] == b"#*#*"[0..4] {
+                    ctype = CommentType::Heading(HeadingLevel::Section);
+                } else if tok_ref[0..4] == b"=-=-"[0..4] {
+                    ctype = CommentType::Heading(HeadingLevel::SubSection);
+                } else if tok_ref[0..4] == b"-.-."[0..4] {
+                    ctype = CommentType::Heading(HeadingLevel::SubSubSection);
+                }
             }
-
             first = false;
         }
 
@@ -1034,10 +1076,10 @@ impl<'a> Scanner<'a> {
             let ftok_ref = ftok.as_ref(self.buffer);
             if ftok_ref == b"$(" {
                 let ctype = self.get_comment(ftok, false);
-                let stype = if ctype == CommentType::Typesetting {
-                    TypesettingComment
-                } else {
-                    Comment
+                let stype = match ctype {
+                    CommentType::Typesetting => TypesettingComment,
+                    CommentType::Heading(level) => HeadingComment(level),
+                    _ => Comment,
                 };
                 return Some(self.out_statement(stype, Span::new2(ftok.start, ftok.start)));
             } else {
@@ -1336,6 +1378,7 @@ impl<'a> Scanner<'a> {
             buffer: self.buffer_ref.clone(),
             diagnostics: Vec::new(),
             span_pool: Vec::new(),
+            outline: Vec::new(),
         };
         let mut top_group = NO_STATEMENT;
         let is_end;
@@ -1473,6 +1516,9 @@ fn collect_definitions(seg: &mut Segment) {
                     label: copy_token(stmt.label.as_ref(buf)),
                     name: copy_token(math[1].as_ref(buf)),
                 });
+            }
+            HeadingComment(level) => {
+                seg.outline.push(HeadingDef { index, level });
             }
             _ => {}
         }


### PR DESCRIPTION
This adds support for getting the outline (chapters, sections, sub-sections) of a database.
When the database option `outline` is set, the positions of the chapter headings is computed and stored during parsing.
The command line option `--outline` activates this options and outputs the outline in text format.