### PR TITLE
Remove Ubuntu 16 from GitHub Actions test matrix

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04, windows-latest, macOS-latest]
+        os: [ubuntu-18.04, ubuntu-20.04, windows-latest, macOS-latest]
         rust: [stable] # [stable, nightly]
     # needs: skip_dups
     # if: ${{ needs.skip_dups.outputs.should_skip != 'true' }}


### PR DESCRIPTION
Ubuntu 16 isn't working properly on GitHub, and its support
will be removed soon (2021-09-20), so let's remove it from
the test matrix.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>