### PR TITLE
Clippy

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -41,18 +41,5 @@ jobs:
       # (or disable those warnings, preferably as specifically as we can).
       - name: Run tests
         run: cargo test --verbose
-
-  clippy:
-    name: Clippy
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        profile: minimal
-        components: clippy
-        default: true
-    - name: Clippy
+      - name: Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -41,3 +41,18 @@ jobs:
       # (or disable those warnings, preferably as specifically as we can).
       - name: Run tests
         run: cargo test --verbose
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        profile: minimal
+        components: clippy
+        default: true
+    - name: Clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -37,6 +37,7 @@ jobs:
         uses: hecrj/setup-rust-action@v1
         with:
           rust-version: ${{ matrix.rust }}
+          components: clippy
       # TODO: Add more static tests, perhaps eventually fail on warnings
       # (or disable those warnings, preferably as specifically as we can).
       - name: Run tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ simple_logger = "1.13.0"
 dot-writer = { version = "0.1.2", optional = true }
 
 [features]
-sysalloc = []
 dot = ["dot-writer"]
 
 [profile]

--- a/src/bit_set.rs
+++ b/src/bit_set.rs
@@ -21,6 +21,7 @@ pub struct Bitset {
     // of small bitsets at the expense of large ones, as Option<Box> only
     // consumes one word of storage if empty, while Vec and Option<Vec> take
     // three.
+    #[allow(clippy::box_vec)]
     tail: Option<Box<Vec<usize>>>,
 }
 
@@ -33,10 +34,7 @@ impl Clone for Bitset {
     fn clone(&self) -> Bitset {
         Bitset {
             head: self.head,
-            tail: match self.tail {
-                None => None,
-                Some(ref tail) => Some(tail.clone()),
-            },
+            tail: self.tail.clone(),
         }
     }
 }
@@ -65,7 +63,7 @@ impl Bitset {
     fn tail(&self) -> &[usize] {
         match self.tail {
             None => Default::default(),
-            Some(ref bx) => &bx,
+            Some(ref bx) => bx,
         }
     }
 

--- a/src/diag.rs
+++ b/src/diag.rs
@@ -187,16 +187,16 @@ fn annotate_diagnostic(notes: &mut Vec<Notation>,
         args: Vec<(&'static str, String)>,
     }
 
-    fn ann<'a>(info: &mut AnnInfo<'a>, mut span: Span) {
+    fn ann(info: &mut AnnInfo, mut span: Span) {
         if span.is_null() {
             span = info.stmt.span();
         }
         info.notes.push(Notation {
             source: info.sset.source_info(info.stmt.segment().id).clone(),
             message: info.s,
-            span: span,
+            span,
             level: info.level,
-            args: mem::replace(&mut info.args, Vec::new()),
+            args: mem::take(&mut info.args),
         })
     }
 
@@ -209,9 +209,9 @@ fn annotate_diagnostic(notes: &mut Vec<Notation>,
     }
 
     let mut info = AnnInfo {
-        notes: notes,
-        sset: sset,
-        stmt: stmt,
+        notes,
+        sset,
+        stmt,
         level: Error,
         s: "",
         args: Vec::new(),

--- a/src/export.rs
+++ b/src/export.rs
@@ -153,17 +153,17 @@ pub fn export_mmp<W: Write>(sset: &SegmentSet,
         for _ in 0..(spaces + indent[cur] - line.len() as u16) {
             line.push(' ')
         }
-        line.push_str(&str::from_utf8(&tc).unwrap());
+        line.push_str(str::from_utf8(&tc).unwrap());
         line.push_str(&String::from_utf8_lossy(&arr.exprs[cur]));
         writeln!(out, "{}", line)?;
     }
     writeln!(out,
                   "\n$={}",
                   ProofTreePrinter {
-                      sset: sset,
-                      nset: nset,
-                      scope: scope,
-                      thm_label: thm_label,
+                      sset,
+                      nset,
+                      scope,
+                      thm_label,
                       style: ProofStyle::Compressed,
                       arr: &arr,
                       initial_chr: 2,

--- a/src/export.rs
+++ b/src/export.rs
@@ -25,6 +25,8 @@ pub enum ExportError {
     Io(io::Error),
     /// Proof verification error
     Verify(Diagnostic),
+    /// Formatting error
+    Format(fmt::Error),
 }
 
 impl From<io::Error> for ExportError {
@@ -37,12 +39,18 @@ impl From<Diagnostic> for ExportError {
         ExportError::Verify(err)
     }
 }
+impl From<fmt::Error> for ExportError {
+    fn from(err: fmt::Error) -> ExportError {
+        ExportError::Format(err)
+    }
+}
 
 impl fmt::Display for ExportError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             ExportError::Io(ref err) => write!(f, "IO error: {}", err),
             ExportError::Verify(ref err) => write!(f, "{:?}", err),
+            ExportError::Format(ref err) => write!(f, "Format error: {:?}", err),
         }
     }
 }
@@ -52,6 +60,7 @@ impl error::Error for ExportError {
         match *self {
             ExportError::Io(ref err) => Some(err),
             ExportError::Verify(_) => None,
+            ExportError::Format(ref err) => Some(err),
         }
     }
 }

--- a/src/formula.rs
+++ b/src/formula.rs
@@ -147,7 +147,7 @@ impl Formula {
             // the model formula is a variable, build or match the substitution
             if let Some(formula) = substitutions.0.get(&other.tree[other_node_id]) {
                 // there already is as substitution for that variable, check equality
-                self.sub_eq(node_id, formula, formula.root).then(|| {()})
+                self.sub_eq(node_id, formula, formula.root).then(|| {})
             } else {
                 // store the new substitution and succeed
                 substitutions.0.insert(other.tree[other_node_id], Box::new(self.sub_formula(node_id)));

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -930,7 +930,7 @@ impl Grammar {
                             if reduce.offset > 0 { write!(buf, "{}({}) / ", as_str(nset.atom_name(reduce.label)), reduce.offset)?; }
                             else { write!(buf, "{} / ", as_str(nset.atom_name(reduce.label)))?; }
                         }
-                        write!(buf, escape(as_str(nset.atom_name(*symbol))).as_str())?;
+                        write!(buf, "{}", escape(as_str(nset.atom_name(*symbol))).as_str())?;
                         digraph
                             .edge(as_string(node_id), as_string(node.next_node_id))
                             .attributes()
@@ -942,7 +942,7 @@ impl Grammar {
                         buf.write_str(escape(as_str(nset.atom_name(*typecode))).as_str())?;
                         for reduce in node.leaf_label.into_iter() {
                             if reduce.offset > 0 { write!(buf, " / {}({})", as_str(nset.atom_name(reduce.label)),reduce.offset)?; }
-                            else { write(buf, " / {}", as_str(nset.atom_name(reduce.label)))?; }
+                            else { write!(buf, " / {}", as_str(nset.atom_name(reduce.label)))?; }
                         }
                         digraph
                             .edge(as_string(node_id), as_string(node.next_node_id))

--- a/src/grammar_tests.rs
+++ b/src/grammar_tests.rs
@@ -14,8 +14,7 @@ const GRAMMAR_DB : &[u8] = b"
 ";
 
 pub fn mkdb(text: &[u8]) -> Database {
-    let mut options = DbOptions::default();
-    options.incremental = true;
+    let options = DbOptions { incremental: true, ..Default::default() };
     let mut db = Database::new(options);
     db.parse("test.mm".to_owned(),
              vec![("test.mm".to_owned(), text.to_owned())]);
@@ -38,9 +37,9 @@ fn test_db_stmt_parse() {
     let sset = db.parse_result().clone();
     let grammar = db.grammar_result().clone();
     let stmt_parse = db.stmt_parse_result().clone();
-    assert!(sset.parse_diagnostics().len() == 0);
-    assert!(grammar.diagnostics().len() == 0);
-    assert!(stmt_parse.diagnostics().len() == 0);
+    assert!(sset.parse_diagnostics().is_empty());
+    assert!(grammar.diagnostics().is_empty());
+    assert!(stmt_parse.diagnostics().is_empty());
 }
 
 #[test]

--- a/src/line_cache.rs
+++ b/src/line_cache.rs
@@ -114,8 +114,8 @@ impl LineCache {
     /// Find the offset just after the end of the line (usually the
     /// location of a '\n', unless we are at the end of the file).
     pub fn line_end(buf: &[u8], offset: usize) -> usize {
-        for pos in offset..buf.len() {
-            if buf[pos] == b'\n' {
+        for (pos, &ch) in buf.iter().enumerate().skip(offset) {
+            if ch == b'\n' {
                 return pos;
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,15 +2,11 @@
 //! databases.  The entry point for all API operations is in the `database`
 //! module, as is a discussion of the data representation.
 #![warn(missing_docs)]
-#![cfg_attr(feature = "sysalloc", feature(alloc_system))]
 #[macro_use]
 extern crate clap;
 extern crate filetime;
 extern crate fnv;
 extern crate regex;
-
-#[cfg(feature = "sysalloc")]
-extern crate alloc_system;
 
 pub mod bit_set;
 pub mod database;

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,19 +97,19 @@ fn main() {
             .multiple(true))
         .get_matches();
 
-    let mut options = DbOptions::default();
-    options.autosplit = matches.is_present("split");
-    options.timing = matches.is_present("timing");
-    options.outline = matches.is_present("outline");
-    options.trace_recalc = matches.is_present("trace-recalc");
-    options.incremental = matches.is_present("repeat");
-    options.jobs = usize::from_str(matches.value_of("jobs").unwrap_or("1"))
-        .expect("validator should check this");
-    options.incremental |= matches.is_present("grammar") 
-        || matches.is_present("parse-stmt") 
-        || matches.is_present("export-grammar-dot") 
-        || matches.is_present("print-grammar") 
-        || matches.is_present("print-formula");
+    let options = DbOptions {
+        autosplit: matches.is_present("split"),
+        timing: matches.is_present("timing"),
+        trace_recalc: matches.is_present("trace-recalc"),
+        incremental: matches.is_present("repeat")
+            || matches.is_present("grammar") 
+            || matches.is_present("parse-stmt") 
+            || matches.is_present("export-grammar-dot") 
+            || matches.is_present("print-grammar") 
+            || matches.is_present("print-formula"),
+        jobs: usize::from_str(matches.value_of("jobs").unwrap_or("1"))
+            .expect("validator should check this"),
+    };
 
     if matches.is_present("debug") {
         SimpleLogger::new().init().unwrap();

--- a/src/outline.rs
+++ b/src/outline.rs
@@ -30,7 +30,7 @@ pub struct OutlineNode {
 
 impl OutlineNode {
     /// Build the root node for a database
-    fn root_node(segments: &Vec<SegmentRef>) -> Self {
+    fn root_node(segments: &[SegmentRef]) -> Self {
         OutlineNode {
             name: copy_token("Database".as_bytes()),
             level: HeadingLevel::Database,
@@ -77,9 +77,9 @@ impl OutlineNode {
 }
 
 /// Builds the overall outline from the different segments
-pub fn build_outline<'a>(node: &mut OutlineNode, sset: &'a Arc<SegmentSet>) {
+pub fn build_outline(node: &mut OutlineNode, sset: &Arc<SegmentSet>) {
     let segments = sset.segments();
-    assert!(segments.len() > 0,"Parse returned no segment!");
+    assert!(!segments.is_empty(),"Parse returned no segment!");
     *node = OutlineNode::root_node(&segments);
 
     for vsr in segments.iter() {

--- a/src/parser_tests.rs
+++ b/src/parser_tests.rs
@@ -10,6 +10,7 @@ use crate::parser::Comparer;
 use std::cmp::Ordering;
 
 #[test]
+#[allow(clippy::many_single_char_names)]
 fn test_segment_order() {
     let mut so = SegmentOrder::new();
     let f = so.start();

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -20,6 +20,7 @@ use std::fmt::Write;
 use std::hash::Hash;
 use std::hash::Hasher;
 use std::collections::hash_map::DefaultHasher;
+use std::collections::hash_map::Entry;
 use std::ops::Range;
 use std::u16;
 use crate::util::HashMap;
@@ -490,16 +491,16 @@ impl<'a, 'b> ProofTreePrinterImpl<'a, 'b> {
 
     fn init_stmt_lookup(&mut self) {
         for tree in &self.p.arr.trees {
-            #[allow(clippy::map_entry)]
-            if !self.stmt_lookup.contains_key(&tree.address) {
-                let label = self.p.sset.statement(tree.address).label();
-                let hyps = if self.p.style.explicit() {
-                    match self.p.scope.get(label) {
+            let p = &self.p;
+            if let Entry::Vacant(entry) = self.stmt_lookup.entry(tree.address) {
+                let label = p.sset.statement(tree.address).label();
+                let hyps = if p.style.explicit() {
+                    match p.scope.get(label) {
                         Some(frame) => {
                             frame.hypotheses
                                 .iter()
                                 .map(|hyp| {
-                                    as_str(self.p
+                                    as_str(p
                                         .sset
                                         .statement(hyp.address())
                                         .label())
@@ -511,7 +512,7 @@ impl<'a, 'b> ProofTreePrinterImpl<'a, 'b> {
                 } else {
                     vec![]
                 };
-                self.stmt_lookup.insert(tree.address, (as_str(label), hyps));
+                entry.insert((as_str(label), hyps));
             }
         }
     }

--- a/src/segment_set.rs
+++ b/src/segment_set.rs
@@ -434,16 +434,14 @@ impl SegmentSet {
                 }
             }
             for seg in segments {
-                #[allow(clippy::branches_sharing_code)]
-                if seg.0.next_file != Span::null() {
-                    state.segments.push(seg);
+                let has_next = seg.0.next_file != Span::null();
+                state.segments.push(seg);
+                if has_next {
                     // wait for include to be done parsing, incorporate it and
                     // recurse
                     let pp = promises.pop_front().unwrap().wait();
                     let nsegs = flat(state, pp);
                     recurse(state, nsegs);
-                } else {
-                    state.segments.push(seg);
                 }
             }
         }

--- a/src/segment_set.rs
+++ b/src/segment_set.rs
@@ -85,12 +85,18 @@ use crate::util::ptr_eq;
 /// We don't want to repeatedly hash tens of MBs of source text; but the
 /// segments are long enough that their lengths are likely to contain enough
 /// entropy already.
-#[derive(Eq,PartialEq,Clone,Debug)]
+#[derive(Eq,Clone,Debug)]
 struct LongBuf(Arc<Vec<u8>>);
 
 impl Hash for LongBuf {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.0.len().hash(state);
+    }
+}
+
+impl PartialEq for LongBuf {
+    fn eq(&self, other: &Self) -> bool {
+        self == other
     }
 }
 
@@ -178,7 +184,7 @@ impl SegmentSet {
             .map(|(&seg_id, &(ref seg, ref _sinfo))| {
                 SegmentRef {
                     id: seg_id,
-                    segment: &seg,
+                    segment: seg,
                 }
             })
             .collect();
@@ -199,7 +205,7 @@ impl SegmentSet {
         self.segments.get(&seg_id).map(|&(ref seg, ref _srcinfo)| {
             SegmentRef {
                 id: seg_id,
-                segment: &seg,
+                segment: seg,
             }
         })
     }
@@ -428,6 +434,7 @@ impl SegmentSet {
                 }
             }
             for seg in segments {
+                #[allow(clippy::branches_sharing_code)]
                 if seg.0.next_file != Span::null() {
                     state.segments.push(seg);
                     // wait for include to be done parsing, incorporate it and

--- a/src/util.rs
+++ b/src/util.rs
@@ -80,7 +80,7 @@ pub fn fast_extend<T: Copy>(vec: &mut Vec<T>, other: &[T]) {
 #[inline(always)]
 pub fn copy_portion(vec: &mut Vec<u8>, from: Range<usize>) {
     let Range { start: copy_start, end: copy_end } = from;
-    assert!(vec.get(from).is_some());
+    assert!(vec.get(from).is_some(), "out of range");
     unsafe {
         let copy_len = copy_end - copy_start;
         vec.reserve(copy_len);

--- a/src/util.rs
+++ b/src/util.rs
@@ -42,6 +42,7 @@ pub fn new_set<K>() -> HashSet<K>
 ///   // GOOD: forcing deref to String, we have only one of those
 ///   assert!(util::ptr_eq::<String>(&a1, &a2));
 ///   ```
+#[allow(clippy::ptr_eq)]
 pub fn ptr_eq<T>(x: &T, y: &T) -> bool {
     x as *const _ == y as *const _
 }
@@ -79,14 +80,15 @@ pub fn fast_extend<T: Copy>(vec: &mut Vec<T>, other: &[T]) {
 #[inline(always)]
 pub fn copy_portion(vec: &mut Vec<u8>, from: Range<usize>) {
     let Range { start: copy_start, end: copy_end } = from;
+    #[allow(clippy::no_effect)]
     &vec[from]; // for the bounds check
     unsafe {
         let copy_len = copy_end - copy_start;
         vec.reserve(copy_len);
 
         let old_len = vec.len();
-        let copy_from = vec.as_ptr().offset(copy_start as isize);
-        let copy_to = vec.as_mut_ptr().offset(old_len as isize);
+        let copy_from = vec.as_ptr().add(copy_start);
+        let copy_to = vec.as_mut_ptr().add(old_len);
         short_copy(copy_from, copy_to, copy_len);
         vec.set_len(old_len + copy_len);
     }
@@ -134,10 +136,10 @@ pub fn find_chapter_header(mut buffer: &[u8]) -> Option<usize> {
             pp += 19;
         }
 
-        return None;
+        None
     }
 
-    const LANDING_STRIP: &'static [u8] =
+    const LANDING_STRIP: &[u8] =
         b"#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#";
 
     fn is_real(buffer: &[u8], mut midp: usize) -> Option<usize> {

--- a/src/util.rs
+++ b/src/util.rs
@@ -80,8 +80,7 @@ pub fn fast_extend<T: Copy>(vec: &mut Vec<T>, other: &[T]) {
 #[inline(always)]
 pub fn copy_portion(vec: &mut Vec<u8>, from: Range<usize>) {
     let Range { start: copy_start, end: copy_end } = from;
-    #[allow(clippy::no_effect)]
-    &vec[from]; // for the bounds check
+    assert!(vec.get(from).is_some());
     unsafe {
         let copy_len = copy_end - copy_start;
         vec.reserve(copy_len);

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -69,7 +69,7 @@ use crate::util::ptr_eq;
 macro_rules! try_assert {
     ( $cond:expr , $($arg:tt)+ ) => {
         if !$cond {
-            Err($($arg)+)?
+            return Err($($arg)+)
         }
     }
 }
@@ -127,7 +127,7 @@ impl ProofBuilder for () {
 
     fn push(&mut self, _: &mut (), _: ()) {}
 
-    fn build(&mut self, _: StatementAddress, _: (), _: &[u8], _: Range<usize>) -> () {}
+    fn build(&mut self, _: StatementAddress, _: (), _: &[u8], _: Range<usize>) {}
 }
 
 /// Working memory used by the verifier on a segment.  This expands for the
@@ -171,7 +171,7 @@ type Result<T> = result::Result<T, Diagnostic>;
 /// discovered until we get here, and a number needs to be assigned to it.
 /// Unfortunately this does mean that it'll be outside the valid range of dv_map
 /// and dv_map checks need to guard against that.
-fn map_var<'a, P: ProofBuilder>(state: &mut VerifyState<'a, P>, token: Atom) -> usize {
+fn map_var<P: ProofBuilder>(state: &mut VerifyState<P>, token: Atom) -> usize {
     let nbit = state.var2bit.len();
     // actually, it _might not_ break anything to have a single variable index
     // allocated by scopeck for all non-$d-ed variables.  after all, they aren't
@@ -185,14 +185,14 @@ fn map_var<'a, P: ProofBuilder>(state: &mut VerifyState<'a, P>, token: Atom) -> 
 fn prepare_hypothesis<'a, P: ProofBuilder>(state: &mut VerifyState<P>, hyp: &'a scopeck::Hyp) {
     let mut vars = Bitset::new();
     let tos = state.stack_buffer.len();
-    match hyp {
-        &Floating(_addr, var_index, _typecode) => {
+    match *hyp {
+        Floating(_addr, var_index, _typecode) => {
             fast_extend(&mut state.stack_buffer,
                         state.nameset.atom_name(state.cur_frame.var_list[var_index]));
             *state.stack_buffer.last_mut().unwrap() |= 0x80;
             vars.set_bit(var_index); // and we have prior knowledge it's identity mapped
         }
-        &Essential(_addr, ref expr) => {
+        Essential(_addr, ref expr) => {
             // this is the first of many subtle variations on the "interpret an
             // ExprFragment" theme in this module.
             for part in &*expr.tail {
@@ -228,7 +228,7 @@ fn prepare_hypothesis<'a, P: ProofBuilder>(state: &mut VerifyState<P>, hyp: &'a 
 /// fails.
 fn prepare_named_hyp<P: ProofBuilder>(state: &mut VerifyState<P>, label: TokenPtr) -> bool {
     for hyp in &*state.cur_frame.hypotheses {
-        if let &Essential(addr, _) = hyp {
+        if let Essential(addr, _) = *hyp {
             assert!(addr.segment_id == state.this_seg.id);
             // we don't allow $e statements to be valid across segments, so this
             // can be done as a local lookup in this_seg.  Since we always
@@ -379,7 +379,7 @@ fn do_substitute_eq(mut compare: &[u8],
             return true;
         }
         *compare = &(*compare)[len..];
-        return false;
+        false
     }
 
     for part in &*expr.tail {
@@ -395,7 +395,7 @@ fn do_substitute_eq(mut compare: &[u8],
         return false;
     }
 
-    return compare.is_empty();
+    compare.is_empty()
 }
 
 // substitute with the _names_ of variables, for the final "did we prove what we
@@ -436,16 +436,16 @@ fn process_hyp<P: ProofBuilder>(state: &mut VerifyState<P>,
                                 -> Result<()> {
     let (ref data, ref slot): (P::Item, StackSlot) = state.stack[ix];
     state.builder.push(datavec, data.clone());
-    match hyp {
-        &Floating(_addr, var_index, typecode) => {
+    match *hyp {
+        Floating(_addr, var_index, typecode) => {
             try_assert!(slot.code == typecode, Diagnostic::StepFloatWrongType);
             state.subst_info[var_index] = (slot.expr.clone(), slot.vars.clone());
         }
-        &Essential(_addr, ref expr) => {
+        Essential(_addr, ref expr) => {
             try_assert!(slot.code == expr.typecode, Diagnostic::StepEssenWrongType);
             try_assert!(do_substitute_eq(&state.stack_buffer[slot.expr.clone()],
                                          frame,
-                                         &expr,
+                                         expr,
                                          &state.subst_info,
                                          &state.stack_buffer),
                         Diagnostic::StepEssenWrong);
@@ -469,7 +469,7 @@ fn execute_step<P: ProofBuilder>(state: &mut VerifyState<P>,
             state.stack.push((data.clone(),
                               StackSlot {
                 vars: vars.clone(),
-                code: code,
+                code,
                 expr: expr.clone(),
             }));
             return Ok(());
@@ -498,7 +498,7 @@ fn execute_step<P: ProofBuilder>(state: &mut VerifyState<P>,
             if let Some(tok) = explicit_stack[sbase + ix] {
                 if state.nameset
                         .lookup_label(tok)
-                        .ok_or(Diagnostic::BadExplicitLabel(copy_token(tok)))?
+                        .ok_or_else(|| Diagnostic::BadExplicitLabel(copy_token(tok)))?
                     .address != hyp.address() {
                     in_order = false;
                     break;
@@ -520,7 +520,7 @@ fn execute_step<P: ProofBuilder>(state: &mut VerifyState<P>,
                     let hyp_ix = (fref.hypotheses
                         .iter()
                         .position(|hyp| hyp.address() == addr)
-                        .ok_or(Diagnostic::BadExplicitLabel(copy_token(tok))))?;
+                        .ok_or_else(|| Diagnostic::BadExplicitLabel(copy_token(tok))))?;
                     try_assert!(assn_hyps[hyp_ix].is_none(),
                                 Diagnostic::DuplicateExplicitLabel(copy_token(tok)));
                     assn_hyps[hyp_ix] = Some(ix);
@@ -594,7 +594,7 @@ fn finalize_step<P: ProofBuilder>(state: &mut VerifyState<P>) -> Result<P::Item>
                 Diagnostic::ProofWrongTypeEnd);
 
     fast_clear(&mut state.temp_buffer);
-    do_substitute_raw(&mut state.temp_buffer, &state.cur_frame, state.nameset);
+    do_substitute_raw(&mut state.temp_buffer, state.cur_frame, state.nameset);
 
     try_assert!(state.stack_buffer[tos.expr.clone()] == state.temp_buffer[..],
                 Diagnostic::ProofWrongExprEnd);
@@ -658,12 +658,12 @@ fn verify_proof<'a, P: ProofBuilder>(state: &mut VerifyState<'a, P>,
         while i < stmt.proof_len() {
             let chunk = stmt.proof_slice_at(i);
             for &ch in chunk {
-                if ch >= b'A' && ch <= b'T' {
+                if (b'A'..=b'T').contains(&ch) {
                     k = k * 20 + (ch - b'A') as usize;
                     execute_step(state, k, None)?;
                     k = 0;
                     can_save = true;
-                } else if ch >= b'U' && ch <= b'Y' {
+                } else if (b'U'..=b'Y').contains(&ch) {
                     k = k * 5 + 1 + (ch - b'U') as usize;
                     try_assert!(k < (u32::max_value() as usize / 20) - 1,
                                 Diagnostic::ProofMalformedVarint);
@@ -787,7 +787,7 @@ fn verify_segment(sset: &SegmentSet,
     }
     VerifySegment {
         source: (*sref).clone(),
-        diagnostics: diagnostics,
+        diagnostics,
         scope_usage: state.scoper.into_usage(),
     }
 }
@@ -840,7 +840,7 @@ pub fn verify_one<P: ProofBuilder>(sset: &SegmentSet,
         this_seg: stmt.segment(),
         scoper: ScopeReader::new(scopes),
         nameset: nset,
-        builder: builder,
+        builder,
         order: &sset.order,
         cur_frame: &dummy_frame,
         stack: Vec::new(),


### PR DESCRIPTION
This is the result of a clippy pass over the whole project.
I've generally accepted clippy's suggestions, except in the following cases where I've added `allow`'s to silence it:

- bit_set.rs:24 : allow(clippy::box_vec) It's obvious in Stefan's comment why he wanted to optimize for space.
- grammar.rs:528: allow(clippy::too_many_arguments) Fixing this means a bigger rearchitecture.  I may open an issue to track it.
- grammar.rs:779: same as above.
- parser_tests.rs:13 : allow(clippy::many_single_char_names) I don't think it makes sense to rename the arguments to pass the clippy here.
- ~~proof.rs:793 : allow(clippy::map_entry) We cannot follow on clippy's suggestion, otherwise we would need to borrow "self" twice~~
- ~~segment_set.rs:437 allow(clippy::branches_sharing_code) Fixed~~
- util.rs:45 allow(clippy::ptr_eq) ~~I'm unsure about this one, but I assume this is different from the default ptr_eq, so~~ we want to keep it. 
- ~~util.rs:83 allow(clippy::no_effect) Code actually has effect, since it enforces bounds check~~

I've also changed the Travis CI to include clippy. @david-a-wheeler could you please check especially if I've done that correctly?