### PR TITLE
Additional grammar tests, iterative parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,12 @@ dependencies = [
 
 [[package]]
 name = "ansi_term"
-version = "0.7.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f46cd5b1d660c938e3f92dfe7a73d832b3281479363dd0cd9c1c2fbf60f7962"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+dependencies = [
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "atty"
@@ -36,9 +39,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "bitflags"
-version = "0.5.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f67931368edf3a9a51d29886d245f1c3db2f1ef0dcc9e35ff70341b78c10d23"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "cfg-if"
@@ -61,14 +64,15 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.5.2"
+version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fee724ff92564914e8aa708919449e0c7b165f7833110b4b1ade9b3a9b17e8"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
  "ansi_term",
+ "atty",
  "bitflags",
- "libc",
  "strsim",
+ "textwrap",
  "unicode-width",
  "vec_map",
 ]
@@ -221,9 +225,18 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.4.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d5f575d5ced6634a5c4cb842163dab907dc7e9148b28dc482d81b8855cbe985"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
 
 [[package]]
 name = "thread-id"
@@ -263,9 +276,9 @@ checksum = "848a1e1181b9f6753b5e96a092749e29b11d19ede67dfbbd6c7dc7e0f49b5338"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.3"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6722facc10989f63ee0e20a83cd4e1714a9ae11529403ac7e0afd069abc39e"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "utf8-ranges"
@@ -275,9 +288,9 @@ checksum = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
 
 [[package]]
 name = "vec_map"
-version = "0.6.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac5efe5cb0fa14ec2f84f83c701c562ee63f6dcc680861b21d65c682adfb05f"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ tinyvec = "1.3.1"
 log = "0.4.14"
 
 # Dependencies for standalone executable, not needed for a library
-clap = "2.5.2"
+clap = "2.33.3"
 simple_logger = "1.13.0"
 
 # Optional dependencies

--- a/src/database.rs
+++ b/src/database.rs
@@ -646,6 +646,18 @@ impl Database {
         })
     }
 
+    /// Verify that printing the formulas of this database gives back the original formulas
+    pub fn verify_parse_stmt(&mut self) {
+        time(&self.options.clone(), "verify_parse_stmt", || {
+            let parse = self.parse_result().clone();
+            let name = self.name_result().clone();
+            let stmt_parse = self.stmt_parse_result().clone();
+            if let Err(diag) = stmt_parse.verify(&parse, &name) {
+                diag::to_annotations(self.parse_result(), vec![diag]);
+            }
+        })
+    }
+
     /// Dump the outline of this database.
     pub fn print_outline(&mut self) {
         time(&self.options.clone(), "print_outline", || {

--- a/src/diag.rs
+++ b/src/diag.rs
@@ -70,6 +70,7 @@ pub enum Diagnostic {
     FloatNotConstant(TokenIndex),
     FloatNotVariable(TokenIndex),
     FloatRedeclared(StatementAddress),
+    FormulaVerificationFailed,
     GrammarAmbiguous(StatementAddress),
     GrammarProvableFloat,
     IoError(String),
@@ -331,6 +332,10 @@ fn annotate_diagnostic(
             info.s = "Previous $f was here";
             info.level = Note;
             ann(&mut info, Span::null());
+        }
+        FormulaVerificationFailed => {
+            info.s = "Formula verification failed at this symbol";
+            ann(&mut info, stmt.span());
         }
         GrammarAmbiguous(prevstmt) => {
             info.s = "Grammar is ambiguous; ";

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -574,11 +574,13 @@ impl Grammar {
             let token_ptr = sref.math_at(1).slice;
             let symbol = names.lookup_symbol(token_ptr).unwrap();
             if symbol.stype == SymbolType::Variable {
-                type_conversions.push((
-                    names.lookup_float(token_ptr).unwrap().typecode_atom,
-                    this_typecode,
-                    this_label,
-                ));
+                let from_typecode = match names.lookup_float(token_ptr) {
+                    Some(lookup_float) => lookup_float.typecode_atom,
+                    _ => {
+                        return Err(Diagnostic::VariableMissingFloat(1));
+                    }
+                };
+                type_conversions.push((from_typecode, this_typecode, this_label));
                 return Ok(()); // we don't need to add the type conversion axiom itself to the grammar (or do we?)
             }
         }
@@ -665,7 +667,6 @@ impl Grammar {
     /// Handle type conversion:
     /// Go through each node and everywhere there is to_typecode(`class`), put a from_typecode(`setvar`),
     /// pointing to a copy of the next node with a leaf to first do a `cv`
-    #[allow(clippy::too_many_arguments)]
     fn perform_type_conversion(
         &mut self,
         from_typecode: TypeCode,
@@ -761,8 +762,9 @@ impl Grammar {
             }
             for (symbol, next_node) in map {
                 if next_node.next_node_id == add_to_node_id {
+                    // avoid infinite recursion
                     continue;
-                } // avoid infinite recursion
+                }
                 if let GrammarNode::Leaf {
                     reduce: r,
                     typecode,
@@ -798,28 +800,29 @@ impl Grammar {
                         "BRANCH for {} to {} {:?}",
                         add_from_node_id, add_to_node_id, next_node.leaf_label
                     );
-                    let new_next_node_id = match self.add_branch_with_reduce(
+                    let (new_next_node_id, new_stored_reduces) = match self.add_branch_with_reduce(
                         add_to_node_id,
                         *symbol,
                         *stype,
                         next_node.leaf_label,
                     ) {
-                        Ok(new_next_node_id) => new_next_node_id,
+                        Ok(new_next_node_id) => (new_next_node_id, stored_reduces),
                         Err(new_next_node_id) => {
+                            let mut new_stored_reduces = stored_reduces;
                             // This is the case where there is already a branch, with a different reduce.
                             // In that case, we have to store the reduce until the copy is finished.
                             for reduce in next_node.leaf_label {
                                 debug!(">> Storing {:?}", reduce);
-                                stored_reduces.push(reduce);
+                                new_stored_reduces.push(reduce);
                             }
-                            new_next_node_id
+                            (new_next_node_id, new_stored_reduces)
                         }
                     };
                     self.clone_branches(
                         next_node.next_node_id,
                         new_next_node_id,
                         nset,
-                        stored_reduces,
+                        new_stored_reduces,
                         make_final,
                     );
                 }
@@ -835,8 +838,9 @@ impl Grammar {
         reduce_vec: &ReduceVec,
     ) {
         if add_from_node_id == add_to_node_id {
+            // nothing to clone here!
             return;
-        } // nothing to clone here!
+        }
         debug!(
             "Clone with reduce {} to {}",
             add_from_node_id, add_to_node_id
@@ -1101,48 +1105,81 @@ impl Grammar {
         );
     }
 
-    #[allow(clippy::too_many_arguments)]
-    fn parse_formula<'a>(
+    fn parse_formula(
         &self,
-        start_node: NodeId,
         sref: &StatementRef,
-        ix: &mut TokenIndex,
         formula_builder: &mut FormulaBuilder,
-        expected_typecodes: &'a [&'a TypeCode],
+        expected_typecodes: Box<[&TypeCode]>,
         nset: &Arc<Nameset>,
         names: &mut NameReader,
-    ) -> Result<TypeCode, Diagnostic> {
-        let mut node = start_node;
+    ) -> Result<(), Diagnostic> {
+        struct StackElement<'a> {
+            node_id: NodeId,
+            expected_typecodes: Box<[&'a TypeCode]>,
+        }
+
+        let mut ix = 1;
+        let mut e = StackElement {
+            node_id: self.root,
+            expected_typecodes,
+        };
+        let mut stack = vec![];
         loop {
-            match self.nodes.get(node) {
+            match self.nodes.get(e.node_id) {
                 GrammarNode::Leaf { reduce, typecode } => {
                     // We found a leaf: REDUCE
                     self.do_reduce(formula_builder, *reduce, nset);
-                    if expected_typecodes.iter().any(|&t| *t == *typecode) {
-                        if *ix != sref.math_len() {
-                            println!(
-                                "Check this out! {} < {} for {:?}",
-                                *ix,
-                                sref.math_len(),
-                                as_str(nset.statement_name(sref))
+
+                    if e.expected_typecodes.iter().any(|&t| *t == *typecode) {
+                        // We found an expected typecode, pop from the stack and continue
+                        if let Some(popped) = stack.pop() {
+                            e = popped;
+                            debug!(
+                                " ++ Finished parsing formula, found typecode {:?}, back to {}",
+                                as_str(nset.atom_name(*typecode)),
+                                e.node_id
                             );
+                            let (_, var_map) = self.get_branch(e.node_id);
+                            match var_map.get(typecode) {
+                                Some(NextNode {
+                                    next_node_id,
+                                    leaf_label,
+                                }) => {
+                                    // Found a sub-formula: First optionally REDUCE and continue
+                                    for reduce in leaf_label.into_iter() {
+                                        self.do_reduce(formula_builder, *reduce, nset);
+                                    }
+
+                                    e.node_id = *next_node_id;
+                                    debug!("   Next Node: {:?}", e.node_id);
+                                }
+                                None => {
+                                    debug!("TODO");
+                                }
+                            }
+                        } else if ix == sref.math_len() {
+                            // We popped the last element from the stack and we are at the end of the math string, success
+                            return Ok(());
+                        } else {
+                            // TODO, we might have parsed a prefix of the expected type, but this does not occur in set.mm
+                            return Err(Diagnostic::UnparseableStatement(ix));
                         }
-                        return Ok(*typecode);
                     } else {
+                        // We have not found the expected typecode, continue from root
                         debug!(" ++ Wrong type obtained, continue.");
                         let (next_node_id, leaf_label) =
                             self.next_var_node(self.root, *typecode).unwrap(); // TODO error case
                         for reduce in leaf_label.into_iter() {
                             self.do_reduce(formula_builder, *reduce, nset);
                         }
-                        node = next_node_id;
+                        e.node_id = next_node_id;
                     }
                 }
                 GrammarNode::Branch { cst_map, var_map } => {
-                    if *ix == sref.math_len() {
+                    if ix == sref.math_len() {
                         return Err(Grammar::too_short(cst_map, nset));
                     }
-                    let token = sref.math_at(*ix);
+                    let token = sref.math_at(ix);
                     let symbol = names.lookup_symbol(token.slice).unwrap();
                     debug!("   {:?}", as_str(nset.atom_name(symbol.atom)));
 
@@ -1157,112 +1194,28 @@ impl Grammar {
                             }
 
                             // Found an atom matching one of our next nodes: SHIFT, to the next node
-                            self.do_shift(sref, ix, nset, names);
-                            node = *next_node_id;
-                            debug!("   Next Node: {:?}", node);
+                            self.do_shift(sref, &mut ix, nset, names);
+                            e.node_id = *next_node_id;
+                            debug!("   Next Node: {:?}", e.node_id);
                         }
                         None => {
                             // No matching constant, search among variables
-                            if var_map.is_empty() || node == self.root {
+                            if var_map.is_empty() || e.node_id == self.root {
                                 return Err(Diagnostic::UnparseableStatement(token.index()));
                             }
 
                             debug!(
-                                " ++ Not in CST map, recursive call expecting {:?}",
+                                " ++ Not in CST map, push stack element and expect {:?}",
                                 var_map.keys()
                             );
-                            let typecode = self.parse_formula(
-                                self.root,
-                                sref,
-                                ix,
-                                formula_builder,
-                                var_map.keys().collect::<Vec<&TypeCode>>().as_slice(),
-                                nset,
-                                names,
-                            )?;
-                            debug!(
-                                " ++ Finished parsing formula, found typecode {:?}, back to {}",
-                                as_str(nset.atom_name(typecode)),
-                                node
-                            );
-                            match var_map.get(&typecode) {
-                                Some(NextNode {
-                                    next_node_id,
-                                    leaf_label,
-                                }) => {
-                                    // Found a sub-formula: First optionally REDUCE and continue
-                                    for reduce in leaf_label.into_iter() {
-                                        self.do_reduce(formula_builder, *reduce, nset);
-                                    }
-
-                                    node = *next_node_id;
-                                    debug!("   Next Node: {:?}", node);
-                                }
-                                None => {
-                                    // No match found, try as a prefix of a larger formula
-                                    let (_, var_map_2) = self.get_branch(self.root);
-                                    match var_map_2.get(&typecode) {
-                                        Some(NextNode {
-                                            next_node_id: next_node_id_2,
-                                            leaf_label: leaf_label_2,
-                                        }) => {
-                                            // Found a sub-formula: First optionally REDUCE and continue
-                                            for reduce in leaf_label_2.into_iter() {
-                                                self.do_reduce(formula_builder, *reduce, nset);
-                                            }
-
-                                            // Found and reduced a sub-formula, to the next node
-                                            debug!(
-                                                " ++ Considering prefix, switching to {}",
-                                                next_node_id_2
-                                            );
-                                            let typecode = self.parse_formula(
-                                                *next_node_id_2,
-                                                sref,
-                                                ix,
-                                                formula_builder,
-                                                var_map
-                                                    .keys()
-                                                    .collect::<Vec<&TypeCode>>()
-                                                    .as_slice(),
-                                                nset,
-                                                names,
-                                            )?;
-                                            debug!(" ++ Finished parsing formula, found typecode {:?}, back to {}", as_str(nset.atom_name(typecode)), node);
-                                            match var_map.get(&typecode) {
-                                                Some(NextNode {
-                                                    next_node_id,
-                                                    leaf_label,
-                                                }) => {
-                                                    // Found a sub-formula: First optionally REDUCE and continue
-                                                    for reduce in leaf_label.into_iter() {
-                                                        self.do_reduce(
-                                                            formula_builder,
-                                                            *reduce,
-                                                            nset,
-                                                        );
-                                                    }
-
-                                                    node = *next_node_id;
-                                                    debug!("   Next Node: {:?}", node);
-                                                }
-                                                None => {
-                                                    // Still no match found, error.
-                                                    return Err(Diagnostic::UnparseableStatement(
-                                                        token.index(),
-                                                    ));
-                                                }
-                                            }
-                                        }
-                                        _ => {
-                                            // Still no match found, error.
-                                            return Err(Diagnostic::UnparseableStatement(
-                                                token.index(),
-                                            ));
-                                        }
-                                    }
-                                }
-                            }
+                            stack.push(e);
+                            e = StackElement {
+                                node_id: self.root,
+                                expected_typecodes: var_map
+                                    .keys()
+                                    .collect::<Vec<&TypeCode>>()
+                                    .into_boxed_slice(),
+                            };
                         }
                     }
                 }
@@ -1304,11 +1257,9 @@ impl Grammar {
         );
 
         self.parse_formula(
-            self.root,
             sref,
-            &mut 1,
             &mut formula_builder,
-            vec![&expected_typecode].as_slice(),
+            Box::new([&expected_typecode]),
             nset,
             names,
         )?;
@@ -1478,6 +1429,27 @@ impl StmtParse {
             }
         }
         out
+    }
+
+    /// Check that printing parsed statements gives back the original formulas
+    pub fn verify(
+        &self,
+        sset: &Arc<SegmentSet>,
+        nset: &Arc<Nameset>,
+    ) -> Result<(), (StatementAddress, Diagnostic)> {
+        for sps in self.segments.values() {
+            for (&sa, &ref formula) in &sps.formulas {
+                let sref = sset.statement(sa);
+                let math_iter = sref
+                    .math_iter()
+                    .map(|token| nset.lookup_symbol(token.slice).unwrap().atom);
+                let fmla_iter = formula.iter(sset, nset);
+                if math_iter.ne(fmla_iter) {
+                    return Err((sa, Diagnostic::FormulaVerificationFailed));
+                }
+            }
+        }
+        Ok(())
     }
 
     /// Writes down all formulas

--- a/src/grammar_tests.rs
+++ b/src/grammar_tests.rs
@@ -1,6 +1,9 @@
 use crate::database::Database;
 use crate::database::DbOptions;
+use crate::diag::Diagnostic;
 use crate::parser::as_str;
+use crate::parser::SegmentId;
+use crate::parser::StatementAddress;
 
 const GRAMMAR_DB: &[u8] = b"
     $c |- wff class ( ) + = $.
@@ -64,3 +67,116 @@ fn test_db_formula() {
         assert!(as_str(names.atom_name(formula.get_by_path(&[2, 2]).unwrap())) == "cA");
     }
 }
+
+// A minimal set.mm-like database with "Garden Paths"
+const GARDEN_PATH_DB: &[u8] = b"
+    $c |- wff class setvar { } <. >. , | e. = $.
+    $( $j syntax 'class'; syntax 'wff'; syntax '|-' as 'wff';
+        type_conversions; ambiguous_prefix { <.   =>   { A ;
+    $)
+    $v ph A B C D x y $.
+    wph $f wff ph $.
+    cA $f class A $.
+    cB $f class B $.
+    cC $f class C $.
+    cD $f class D $.
+    vx $f setvar x $.
+    vy $f setvar y $.
+    cv $a class x $.
+    weq $a wff A = B $.
+    csn $a class { A } $.
+    cop $a class <. A , B >. $.
+    copab $a class { <. x , y >. e. A | ph } $.
+    formula1 $a |- A = { <. B , C >. } $.
+    formula2 $a |- A = { <. x , y >. } $.
+    formula3 $a |- A = { <. x , y >. e. B | C = D } $.
+";
+
+#[test]
+fn test_garden_path_1() {
+    let mut db = mkdb(GARDEN_PATH_DB);
+    let sset = db.parse_result().clone();
+    let stmt_parse = db.stmt_parse_result().clone();
+    let names = db.name_result().clone();
+    assert!(sset.parse_diagnostics().is_empty());
+    let sref = db.statement("formula1").unwrap();
+    let formula = stmt_parse.get_formula(&sref).unwrap();
+    assert!(as_str(names.atom_name(formula.get_by_path(&[]).unwrap())) == "weq");
+    assert!(as_str(names.atom_name(formula.get_by_path(&[1]).unwrap())) == "cA");
+    assert!(as_str(names.atom_name(formula.get_by_path(&[2]).unwrap())) == "csn");
+    assert!(as_str(names.atom_name(formula.get_by_path(&[2, 1]).unwrap())) == "cop");
+    assert!(as_str(names.atom_name(formula.get_by_path(&[2, 1, 1]).unwrap())) == "cB");
+    assert!(as_str(names.atom_name(formula.get_by_path(&[2, 1, 2]).unwrap())) == "cC");
+}
+
+#[test]
+fn test_garden_path_2() {
+    let mut db = mkdb(GARDEN_PATH_DB);
+    let stmt_parse = db.stmt_parse_result().clone();
+    let names = db.name_result().clone();
+    let sref = db.statement("formula2").unwrap();
+    let formula = stmt_parse.get_formula(&sref).unwrap();
+    assert!(as_str(names.atom_name(formula.get_by_path(&[]).unwrap())) == "weq");
+    assert!(as_str(names.atom_name(formula.get_by_path(&[1]).unwrap())) == "cA");
+    assert!(as_str(names.atom_name(formula.get_by_path(&[2]).unwrap())) == "csn");
+    assert!(as_str(names.atom_name(formula.get_by_path(&[2, 1]).unwrap())) == "cop");
+    assert!(as_str(names.atom_name(formula.get_by_path(&[2, 1, 1]).unwrap())) == "cv");
+    assert!(as_str(names.atom_name(formula.get_by_path(&[2, 1, 1, 1]).unwrap())) == "vx");
+    assert!(as_str(names.atom_name(formula.get_by_path(&[2, 1, 1]).unwrap())) == "cv");
+    assert!(as_str(names.atom_name(formula.get_by_path(&[2, 1, 2, 1]).unwrap())) == "vy");
+}
+
+#[test]
+fn test_garden_path_3() {
+    let mut db = mkdb(GARDEN_PATH_DB);
+    let stmt_parse = db.stmt_parse_result().clone();
+    let names = db.name_result().clone();
+    let sref = db.statement("formula3").unwrap();
+    let formula = stmt_parse.get_formula(&sref).unwrap();
+    assert!(as_str(names.atom_name(formula.get_by_path(&[]).unwrap())) == "weq");
+    assert!(as_str(names.atom_name(formula.get_by_path(&[1]).unwrap())) == "cA");
+    assert!(as_str(names.atom_name(formula.get_by_path(&[2]).unwrap())) == "copab");
+    assert!(as_str(names.atom_name(formula.get_by_path(&[2, 1]).unwrap())) == "vx");
+    assert!(as_str(names.atom_name(formula.get_by_path(&[2, 2]).unwrap())) == "vy");
+    assert!(as_str(names.atom_name(formula.get_by_path(&[2, 3]).unwrap())) == "cB");
+    assert!(as_str(names.atom_name(formula.get_by_path(&[2, 4]).unwrap())) == "weq");
+    assert!(as_str(names.atom_name(formula.get_by_path(&[2, 4, 1]).unwrap())) == "cC");
+    assert!(as_str(names.atom_name(formula.get_by_path(&[2, 4, 2]).unwrap())) == "cD");
+}
+
+macro_rules! sa {
+    ($id: expr, $index:expr) => {
+        StatementAddress {
+            segment_id: SegmentId($id),
+            index: $index,
+        }
+    };
+}
+
+macro_rules! grammar_test {
+    ($name:ident, $text:expr, $id: expr, $index:expr, $diag:expr) => {
+        #[test]
+        fn $name() {
+            let mut db = mkdb($text);
+            let sset = db.parse_result().clone();
+            let grammar = db.grammar_result();
+            assert!(sset.parse_diagnostics().is_empty());
+            assert_eq!(grammar.diagnostics(), &[(sa!($id, $index), $diag)]);
+        }
+    };
+}
+
+grammar_test!(
+    test_missing_float,
+    b"$c setvar $. $v x $. vx $a setvar x $.",
+    2,
+    2,
+    Diagnostic::VariableMissingFloat(1)
+);
+grammar_test!(
+    test_ambiguous,
+    b"$c A B $. a1 $a A B $. a2 $a A B $.",
+    2,
+    2,
+    Diagnostic::GrammarAmbiguous(sa!(2, 1))
+);

--- a/src/grammar_tests.rs
+++ b/src/grammar_tests.rs
@@ -72,7 +72,7 @@ fn test_db_formula() {
 const GARDEN_PATH_DB: &[u8] = b"
     $c |- wff class setvar { } <. >. , | e. = $.
     $( $j syntax 'class'; syntax 'wff'; syntax '|-' as 'wff';
-        type_conversions; ambiguous_prefix { <.   =>   { A ;
+        type_conversions; garden_path { <.   =>   { A ;
     $)
     $v ph A B C D x y $.
     wph $f wff ph $.

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,6 +96,11 @@ fn main() {
                 .short("p"),
         )
         .arg(
+            Arg::with_name("verify-parse-stmt")
+                .help("Check that printing parsed statements gives back the original formulas")
+                .long("verify-parse-stmt"),
+        )
+        .arg(
             Arg::with_name("print-grammar")
                 .help("Print the database's grammar")
                 .long("print-grammar")
@@ -167,6 +172,7 @@ fn main() {
         incremental: matches.is_present("repeat")
             || matches.is_present("grammar")
             || matches.is_present("parse-stmt")
+            || matches.is_present("verify-parse-stmt")
             || matches.is_present("export-grammar-dot")
             || matches.is_present("print-grammar")
             || matches.is_present("print-formula"),
@@ -208,6 +214,10 @@ fn main() {
             types.push(DiagnosticClass::StmtParse);
         }
 
+        if matches.is_present("verify-parse-stmt") {
+            db.verify_parse_stmt();
+        }
+
         let mut lc = LineCache::default();
         let mut count = 0;
         for notation in db.diag_notations(types) {
@@ -215,10 +225,6 @@ fn main() {
             count += 1;
         }
         println!("{} diagnostics issued.", count);
-
-        if matches.is_present("outline") {
-            db.print_outline();
-        }
 
         if matches.is_present("print-grammar") {
             db.print_grammar();


### PR DESCRIPTION
This adds several new grammar tests:

- a new "Verify Parse Statements" command line, which "flattens" the formula trees and verifies that each formula matches the original.
- cargo tests for a minimal database with "garden paths",
- cargo tests for some grammar errors,

Also, the `parse_formula` function was recursive, which required many function arguments. This function is now iterative, and much fewer arguments are required.