### PR TITLE
Handling a special case

### DIFF
--- a/src/grammar_tests.rs
+++ b/src/grammar_tests.rs
@@ -75,6 +75,7 @@ fn test_parse_formula() {
     let names = db.name_result().clone();
     let grammar = db.grammar_result().clone();
     let wff = names.lookup_symbol(b"wff").unwrap().atom;
+    let class = names.lookup_symbol(b"class").unwrap().atom;
     let a = names.lookup_symbol(b"A").unwrap().atom;
     let b = names.lookup_symbol(b"B").unwrap().atom;
     let eq = names.lookup_symbol(b"=").unwrap().atom;
@@ -83,7 +84,11 @@ fn test_parse_formula() {
     let close_parens = names.lookup_symbol(b")").unwrap().atom;
     let fmla_vec = vec![a, eq, open_parens, b, plus, a, close_parens];
     let formula = grammar
-        .parse_formula(&mut fmla_vec.clone().into_iter(), Box::new([&wff]), &names)
+        .parse_formula(
+            &mut fmla_vec.clone().into_iter(),
+            Box::new([&wff, &class]),
+            &names,
+        )
         .unwrap();
     assert!(as_str(names.atom_name(formula.get_by_path(&[]).unwrap())) == "weq");
     assert!(as_str(names.atom_name(formula.get_by_path(&[1]).unwrap())) == "cA");
@@ -204,4 +209,11 @@ grammar_test!(
     2,
     2,
     Diagnostic::GrammarAmbiguous(sa!(2, 1))
+);
+grammar_test!(
+    test_float_not_var,
+    b"$c setvar $. vx $f setvar x $.",
+    2,
+    1,
+    Diagnostic::FloatNotVariable(1)
 );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,3 +24,6 @@ pub mod util;
 pub mod verify;
 
 pub use database::Database;
+pub use formula::Formula;
+pub use formula::Label;
+pub use formula::Symbol;


### PR DESCRIPTION
This is the case where one of the type codes expected appears as a substring of the expression to be parsed.
Also added handling a "FloatNotVariable" error case.