### PR TITLE
Substitution API, Grammar fix

### DIFF
--- a/src/formula.rs
+++ b/src/formula.rs
@@ -33,6 +33,7 @@ use crate::util::HashMap;
 use crate::verify::ProofBuilder;
 use crate::Database;
 use core::ops::Index;
+use std::collections::hash_map::Iter;
 use std::fmt::Debug;
 use std::fmt::Display;
 use std::iter::FromIterator;
@@ -90,6 +91,24 @@ impl Substitutions {
     pub fn get(&self, label: Label) -> Option<&Formula> {
         self.0.get(&label)
     }
+
+    /// An iterator visiting all substitutions in arbitrary order.
+    /// The iterator element type is `(&Label, &Formula)`.
+    #[inline]
+    #[must_use]
+    pub fn iter(&self) -> Iter<'_, Label, Formula> {
+        self.0.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a Substitutions {
+    type Item = (&'a Label, &'a Formula);
+    type IntoIter = Iter<'a, Label, Formula>;
+
+    #[inline]
+    fn into_iter(self) -> Iter<'a, Label, Formula> {
+        self.iter()
+    }
 }
 
 /// A [`Substitutions`] reference in the context of a [`Database`].
@@ -142,6 +161,12 @@ impl Formula {
     pub fn dump(&self, nset: &Nameset) {
         println!("  Root: {}", self.root);
         self.tree.dump(|atom| as_str(nset.atom_name(*atom)));
+    }
+
+    /// Returns whether this formula consists in a single token.
+    #[must_use]
+    pub fn is_singleton(&self) -> bool {
+        !self.tree.has_children(self.root)
     }
 
     /// Returns the label obtained when following the given path.

--- a/src/grammar_tests.rs
+++ b/src/grammar_tests.rs
@@ -127,6 +127,22 @@ fn test_db_32_formula() {
     }
 }
 
+#[test]
+fn test_setvar_as_class() {
+    let mut db = mkdb(GRAMMAR_DB_32);
+    let grammar = db.grammar_pass().clone();
+    let names = db.name_pass().clone();
+    let class_symbol = names.lookup_symbol(b"class").unwrap().atom;
+    let x_symbol = names.lookup_symbol(b"x").unwrap().atom;
+    {
+        let formula = grammar
+            .parse_formula(&mut vec![x_symbol].into_iter(), &[class_symbol], &names)
+            .unwrap();
+        assert!(as_str(names.atom_name(formula.get_by_path(&[]).unwrap())) == "cv");
+        assert!(as_str(names.atom_name(formula.get_by_path(&[1]).unwrap())) == "vx");
+    }
+}
+
 // This grammar exposes issue #43 in the statement parser
 const GRAMMAR_DB_43: &[u8] = b"
     $c |- wff class setvar ( ) { } = e. | |-> /\\ $.


### PR DESCRIPTION
* Adds an API to iterate through a list of substitutions,
* This also fixes grammatical parsing for a special case (`class x`, which was not recognized as a simple [cv, vx]).
