### PR TITLE
refactor outline construction

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -591,9 +591,7 @@ impl Database {
     pub fn outline_pass(&mut self) -> &Arc<Outline> {
         if self.outline.is_none() {
             time(&self.options.clone(), "outline", || {
-                let parse = self.parse_result().clone();
-                let mut outline = Outline::default();
-                parse.build_outline(&mut outline);
+                let outline = self.parse_result().build_outline();
                 self.outline = Some(Arc::new(outline));
             })
         }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -24,7 +24,7 @@ impl<TreeItem> Default for Tree<TreeItem> {
     }
 }
 
-impl<TreeItem: Clone> Tree<TreeItem> {
+impl<TreeItem> Tree<TreeItem> {
     /// Create a new node with the given item and children (previously added to the tree)
     /// This way of constructing the tree forces to use a bottom-up approach,
     /// where the leafs are added first, followed by the branch nodes.
@@ -44,7 +44,7 @@ impl<TreeItem: Clone> Tree<TreeItem> {
                 "Children added to a node shall not be chained yet!"
             );
         }
-        self.nodes.push(new_node.clone());
+        self.nodes.push(new_node);
         self.nodes.len()
     }
 


### PR DESCRIPTION
* `Outline` no longer implements `Default`. (The default value was not a valid outline, because the `root` index was out of bounds of the tree.)
* `build_outline()` now returns the `Outline` instead of modifying the default value.
* The implementation of `build_outline` has been refactored:
  * less `unwrap`s needed
  * Use a single `sibling_stack` instead of a vector-of-vectors for fewer allocations
