### PR TITLE
add $t comment parser

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -111,6 +111,7 @@ use crate::outline::Outline;
 use crate::outline::OutlineNodeRef;
 use crate::parser::Comparer;
 use crate::parser::StatementRef;
+use crate::parser::TypesettingData;
 use crate::proof::ProofTreeArray;
 use crate::scopeck;
 use crate::scopeck::ScopeResult;
@@ -390,6 +391,7 @@ pub struct Database {
     scopes: Option<Arc<ScopeResult>>,
     prev_verify: Option<Arc<VerifyResult>>,
     verify: Option<Arc<VerifyResult>>,
+    typesetting: Option<Arc<TypesettingData>>,
     outline: Option<Arc<Outline>>,
     grammar: Option<Arc<Grammar>>,
     stmt_parse: Option<Arc<StmtParse>>,
@@ -421,6 +423,7 @@ impl Drop for Database {
             self.prev_nameset = None;
             self.nameset = None;
             Arc::make_mut(&mut self.segments).clear();
+            self.typesetting = None;
             self.outline = None;
         });
     }
@@ -441,6 +444,7 @@ impl Database {
             nameset: None,
             scopes: None,
             verify: None,
+            typesetting: None,
             outline: None,
             grammar: None,
             stmt_parse: None,
@@ -485,6 +489,7 @@ impl Database {
             self.nameset = None;
             self.scopes = None;
             self.verify = None;
+            self.typesetting = None;
             self.outline = None;
             self.grammar = None;
         });
@@ -584,6 +589,27 @@ impl Database {
     pub fn verify_result(&self) -> &Arc<VerifyResult> {
         self.verify.as_ref().expect(
             "The database has not run `verify_pass()`. Please ensure it is run before calling depdending methods."
+        )
+    }
+
+    /// Computes and returns the root node of the outline.
+    pub fn typesetting_pass(&mut self) -> &Arc<TypesettingData> {
+        if self.typesetting.is_none() {
+            time(&self.options.clone(), "typesetting", || {
+                let typesetting = self.parse_result().build_typesetting_data();
+                self.typesetting = Some(Arc::new(typesetting));
+            })
+        }
+        self.typesetting_result()
+    }
+
+    /// Returns the root node of the typesetting.
+    /// Panics if [`Database::typesetting_pass`] was not previously called.
+    #[inline]
+    #[must_use]
+    pub fn typesetting_result(&self) -> &Arc<TypesettingData> {
+        self.typesetting.as_ref().expect(
+            "The database has not run `typesetting_pass()`. Please ensure it is run before calling depdending methods."
         )
     }
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -111,11 +111,11 @@ use crate::outline::Outline;
 use crate::outline::OutlineNodeRef;
 use crate::parser::Comparer;
 use crate::parser::StatementRef;
-use crate::parser::TypesettingData;
 use crate::proof::ProofTreeArray;
 use crate::scopeck;
 use crate::scopeck::ScopeResult;
 use crate::segment_set::SegmentSet;
+use crate::typesetting::TypesettingData;
 use crate::verify;
 use crate::verify::VerifyResult;
 use annotate_snippets::snippet::Snippet;
@@ -592,7 +592,7 @@ impl Database {
         )
     }
 
-    /// Computes and returns the root node of the outline.
+    /// Computes and returns the typesetting data.
     pub fn typesetting_pass(&mut self) -> &Arc<TypesettingData> {
         if self.typesetting.is_none() {
             time(&self.options.clone(), "typesetting", || {
@@ -603,7 +603,7 @@ impl Database {
         self.typesetting_result()
     }
 
-    /// Returns the root node of the typesetting.
+    /// Returns the typesetting data.
     /// Panics if [`Database::typesetting_pass`] was not previously called.
     #[inline]
     #[must_use]
@@ -822,6 +822,14 @@ impl Database {
     pub fn print_outline(&self) {
         time(&self.options, "print_outline", || {
             self.outline_result().dump(self);
+        })
+    }
+
+    /// Dump the typesetting information.
+    /// Requires: [`Database::typesetting_pass`]
+    pub fn print_typesetting(&self) {
+        time(&self.options, "print_typesetting", || {
+            self.typesetting_result().dump();
         })
     }
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -875,6 +875,9 @@ impl Database {
         if types.contains(&DiagnosticClass::StmtParse) {
             diags.extend(self.stmt_parse_pass().diagnostics());
         }
+        if types.contains(&DiagnosticClass::Typesetting) {
+            diags.extend(self.typesetting_pass().diagnostics.iter().cloned());
+        }
         time(&self.options.clone(), "diag", move || {
             diag::to_annotations(self.parse_result(), &mut lc, diags, f)
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,7 @@ pub mod outline;
 pub mod parser;
 pub mod proof;
 pub mod scopeck;
+pub mod typesetting;
 pub mod verify;
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ fn main() {
         (@arg timing: --timing "Print milliseconds after each stage")
         (@arg verify: -v --verify "Check proof validity")
         (@arg outline: -O --outline "Show database outline")
+        (@arg typesetting: -t --typesetting "Show typesetting information")
         (@arg grammar: -g --grammar "Check grammar")
         (@arg parse_stmt: -p --("parse-stmt")
             "Parse all statements according to the database's grammar")
@@ -130,6 +131,11 @@ fn main() {
         if matches.is_present("outline") {
             db.outline_pass();
             db.print_outline();
+        }
+
+        if matches.is_present("typesetting") {
+            db.typesetting_pass();
+            db.print_typesetting();
         }
 
         if let Some(exps) = matches.values_of_lossy("export") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,8 @@ fn main() {
         (@arg timing: --timing "Print milliseconds after each stage")
         (@arg verify: -v --verify "Check proof validity")
         (@arg outline: -O --outline "Show database outline")
-        (@arg typesetting: -t --typesetting "Show typesetting information")
+        (@arg print_typesetting: --("dump-typesetting") "Show typesetting information")
+        (@arg parse_typesetting: -t --("parse-typesetting") "Parse typesetting information")
         (@arg grammar: -g --grammar "Check grammar")
         (@arg parse_stmt: -p --("parse-stmt")
             "Parse all statements according to the database's grammar")
@@ -103,6 +104,10 @@ fn main() {
             types.push(DiagnosticClass::StmtParse);
         }
 
+        if matches.is_present("parse_typesetting") {
+            types.push(DiagnosticClass::Typesetting);
+        }
+
         if matches.is_present("verify_parse_stmt") {
             db.stmt_parse_pass();
             db.verify_parse_stmt();
@@ -133,7 +138,7 @@ fn main() {
             db.print_outline();
         }
 
-        if matches.is_present("typesetting") {
+        if matches.is_present("print_typesetting") {
             db.typesetting_pass();
             db.print_typesetting();
         }

--- a/src/outline.rs
+++ b/src/outline.rs
@@ -430,7 +430,8 @@ impl SegmentSet {
         // Finally, pop everything from the stack onto the tree
         let mut last_sibling_idx = 0;
         for (node, sibling_idx) in node_stack.into_iter().rev() {
-            let node_id = std::mem::replace(&mut current_node, node).add_to_tree(&mut tree, &sibling_stack[sibling_idx..]);
+            let node_id = std::mem::replace(&mut current_node, node)
+                .add_to_tree(&mut tree, &sibling_stack[sibling_idx..]);
             sibling_stack.truncate(sibling_idx);
             sibling_stack.push(node_id);
             last_sibling_idx = sibling_idx;

--- a/src/outline.rs
+++ b/src/outline.rs
@@ -426,13 +426,16 @@ impl SegmentSet {
                 ));
             }
         }
+
         // Finally, pop everything from the stack onto the tree
+        let mut last_sibling_idx = 0;
         for (node, sibling_idx) in node_stack.into_iter().rev() {
-            let node_id = node.add_to_tree(&mut tree, &sibling_stack[sibling_idx..]);
+            let node_id = std::mem::replace(&mut current_node, node).add_to_tree(&mut tree, &sibling_stack[sibling_idx..]);
             sibling_stack.truncate(sibling_idx);
             sibling_stack.push(node_id);
+            last_sibling_idx = sibling_idx;
         }
-        let root = current_node.add_to_tree(&mut tree, &sibling_stack);
+        let root = current_node.add_to_tree(&mut tree, &sibling_stack[..=last_sibling_idx]);
         tree[root].parent = root;
 
         Outline {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1883,9 +1883,15 @@ impl SegmentSet {
             };
 
             match cmd.as_ref(buf) {
-                b"latexdef" => data.latex_defs.push((as_(&mut rest)?, sum(rest)?)),
-                b"htmldef" => data.html_defs.push((as_(&mut rest)?, sum(rest)?)),
-                b"althtmldef" => data.alt_html_defs.push((as_(&mut rest)?, sum(rest)?)),
+                b"latexdef" => {
+                    data.latex_defs.insert(as_(&mut rest)?, sum(rest)?);
+                }
+                b"htmldef" => {
+                    data.html_defs.insert(as_(&mut rest)?, sum(rest)?);
+                }
+                b"althtmldef" => {
+                    data.alt_html_defs.insert(as_(&mut rest)?, sum(rest)?);
+                }
                 b"htmlvarcolor" => data.html_var_color.push(sum(rest)?),
                 b"htmltitle" => data.html_title = Some(sum(rest)?),
                 b"htmlhome" => data.html_home = Some(sum(rest)?),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -47,6 +47,7 @@
 
 use crate::diag::Diagnostic;
 use crate::segment_set::SegmentSet;
+use crate::typesetting::TypesettingData;
 use std::cmp;
 use std::cmp::Ordering;
 use std::fmt::Debug;
@@ -1807,138 +1808,6 @@ pub fn dummy_segment(diag: Diagnostic) -> Arc<Segment> {
     let mut seg = parse_segments(&Arc::new(Vec::new())).pop().unwrap();
     Arc::get_mut(&mut seg).unwrap().diagnostics.push((0, diag));
     seg
-}
-
-/// The parsed `$t` comment data.
-#[derive(Debug, Default, Clone)]
-pub struct TypesettingData {
-    /// LaTeX definitions are used to replace a token with a piece of latex syntax.
-    /// Each entry has the form `(token, replacement)`.
-    /// ```text
-    /// latexdef "ph" as "\varphi";
-    /// ```
-    pub latex_defs: Vec<(Token, Token)>,
-
-    /// HTML definitions are used to replace a token with a piece of HTML syntax.
-    /// This version will generally be used for the GIF rendering version of the web pages.
-    /// Each entry has the form `(token, replacement)`.
-    /// ```text
-    /// htmldef "ph" as "<IMG SRC='_varphi.gif' WIDTH=11 HEIGHT=19 ALT=' ph' TITLE='ph'>";
-    /// ```
-    pub html_defs: Vec<(Token, Token)>,
-
-    /// HTML definitions are used to replace a token with a piece of HTML syntax.
-    /// This version will generally be used for the unicode rendering version of the web pages.
-    /// Each entry has the form `(token, replacement)`.
-    /// ```text
-    /// althtmldef "ph" as "<SPAN CLASS=wff STYLE='color:blue'>&#x1D711;</SPAN>";
-    /// ```
-    pub alt_html_defs: Vec<(Token, Token)>,
-
-    /// A piece of HTML to give the variable color key. All `htmlvarcolor` directives are given
-    /// separately here, but they are logically concatenated with spaces for rendering.
-    /// ```text
-    /// htmlvarcolor '<SPAN CLASS=wff STYLE="color:blue;font-style:normal">wff</SPAN> '
-    ///   + '<SPAN CLASS=setvar STYLE="color:red;font-style:normal">setvar</SPAN> '
-    ///   + '<SPAN CLASS=class STYLE="color:#C3C;font-style:normal">class</SPAN>';
-    /// ```
-    pub html_var_color: Vec<Token>,
-
-    /// The title of the generated HTML page.
-    /// ```text
-    /// htmltitle "Metamath Proof Explorer";
-    /// ```
-    pub html_title: Option<Token>,
-
-    /// The link to the home page in the generated HTML page.
-    /// ```text
-    /// htmlhome '<A HREF="mmset.html"><FONT SIZE=-2 FACE=sans-serif>' +
-    ///     '<IMG SRC="mm.gif" BORDER=0 ALT='  +
-    ///     '"Home" HEIGHT=32 WIDTH=32 ALIGN=MIDDLE STYLE="margin-bottom:0px">' +
-    ///     'Home</FONT></A>';
-    /// ```
-    pub html_home: Option<Token>,
-
-    /// The relative path from the unicode version to the GIF version. Used for cross references.
-    /// (This is a set.mm specific hack.)
-    /// ```text
-    /// htmldir "../mpegif/";
-    /// ```
-    pub html_dir: Option<Token>,
-
-    /// The relative path from the GIF version to the unicode version. Used for cross references.
-    /// (This is a set.mm specific hack.)
-    /// ```text
-    /// althtmldir "../mpeuni/";
-    /// ```
-    pub alt_html_dir: Option<Token>,
-
-    /// Optional file where bibliographic references are kept.
-    /// ```text
-    /// htmlbibliography "mmset.html";
-    /// ```
-    pub html_bibliography: Option<Token>,
-
-    /// Custom CSS to be placed in the header of generated files.
-    /// Note that any `\n` escapes are not yet replaced by newlines in this `html_css` variable;
-    /// library consumers are responsible for performing this replacement.
-    /// ```text
-    /// htmlcss '<STYLE TYPE="text/css">\n' +
-    ///   '</STYLE>\n' +
-    ///   '<LINK href="mmset.css" title="mmset"\n' +
-    ///   '    rel="stylesheet" type="text/css">\n';
-    /// ```
-    pub html_css: Option<Token>,
-
-    /// Tag(s) for the main SPAN surrounding all Unicode math.
-    /// ```text
-    /// htmlfont 'CLASS=math';
-    /// ```
-    pub html_font: Option<Token>,
-
-    /// A label, such that everything after this label uses the `ext_*` variables instead of the
-    /// regular ones.
-    /// (This is a set.mm specific hack.)
-    /// ```text
-    /// exthtmllabel "chil";
-    /// ```
-    pub ext_html_label: Option<Token>,
-
-    /// The title of the generated HTML page, for the Hilbert Space extension.
-    /// (This is a set.mm specific hack.)
-    /// ```text
-    /// exthtmltitle "Hilbert Space Explorer";
-    /// ```
-    pub ext_html_title: Option<Token>,
-
-    /// The link to the home page in the generated HTML page, for the Hilbert Space extension.
-    /// (This is a set.mm specific hack.)
-    /// ```text
-    /// exthtmlhome '<A HREF="mmhil.html"><FONT SIZE=-2 FACE=sans-serif>' +
-    ///    '<IMG SRC="atomic.gif" BORDER=0 ALT='  +
-    ///    '"Home" HEIGHT=32 WIDTH=32 ALIGN=MIDDLE STYLE="margin-bottom:0px">' +
-    ///    'Home</FONT></A>';
-    /// ```
-    pub ext_html_home: Option<Token>,
-
-    /// Optional file where bibliographic references are kept, for the Hilbert Space extension.
-    /// (This is a set.mm specific hack.)
-    /// ```text
-    /// exthtmlbibliography "mmhil.html";
-    /// ```
-    pub ext_html_bibliography: Option<Token>,
-
-    /// Optional link(s) to other versions of the theorem page.  A "*" is replaced
-    /// with the label of the current theorem.  If you need a literal "*" as part
-    /// of the URL, use the alternate URL encoding "%2A". (Note that `*` characters are not
-    /// interpreted in this string; library consumers are responsible for implementing this spec.)
-    /// ```text
-    /// htmlexturl '<A HREF="http://metamath.tirix.org/*.html">'
-    ///     + 'Structured version</A>&nbsp;&nbsp; '
-    ///     + '<A HREF="https://expln.github.io/metamath/asrt/*.html">'
-    ///     + 'Visualization version</A>&nbsp;&nbsp; ';
-    /// ```
-    pub html_ext_url: Option<Token>,
 }
 
 fn parse_string_sum(mut rest: std::slice::Iter<'_, CommandToken>) -> Token {

--- a/src/parser_tests.rs
+++ b/src/parser_tests.rs
@@ -1,5 +1,4 @@
 use crate::database::Database;
-use crate::database::DbOptions;
 use crate::diag::Diagnostic;
 use crate::parser::Comparer;
 use crate::parser::SegmentOrder;
@@ -36,8 +35,7 @@ fn test_segment_order() {
 }
 
 fn mkdb(text: &[u8]) -> Database {
-    let dbo = DbOptions::default();
-    let mut db = Database::new(dbo);
+    let mut db = Database::default();
     db.parse(
         "test.mm".to_owned(),
         vec![("test.mm".to_owned(), text.to_owned())],

--- a/src/segment_set.rs
+++ b/src/segment_set.rs
@@ -226,7 +226,7 @@ impl SegmentSet {
     pub(crate) fn parser_commands(&self) -> Vec<(StatementAddress, Command)> {
         let mut out = Vec::new();
         for sref in self.segments() {
-            for &(ix, ref command) in &sref.commands {
+            for &(ix, ref command) in &sref.j_commands {
                 out.push((StatementAddress::new(sref.id, ix), command.clone()));
             }
         }

--- a/src/segment_set.rs
+++ b/src/segment_set.rs
@@ -51,7 +51,7 @@
 use crate::database::{DbOptions, Executor, Promise};
 use crate::diag::Diagnostic;
 use crate::parser::{
-    self, Command, Comparer, Segment, SegmentId, SegmentOrder, SegmentRef, Span, StatementAddress,
+    self, Comparer, Segment, SegmentId, SegmentOrder, SegmentRef, Span, StatementAddress,
     StatementRef,
 };
 use crate::util::{find_chapter_header, HashMap, HashSet};
@@ -217,17 +217,6 @@ impl SegmentSet {
         for sref in self.segments() {
             for &(ix, ref d) in &sref.diagnostics {
                 out.push((StatementAddress::new(sref.id, ix), d.clone()));
-            }
-        }
-        out
-    }
-
-    /// Returns the commands parsed from the $j comments
-    pub(crate) fn parser_commands(&self) -> Vec<(StatementAddress, Command)> {
-        let mut out = Vec::new();
-        for sref in self.segments() {
-            for &(ix, ref command) in &sref.j_commands {
-                out.push((StatementAddress::new(sref.id, ix), command.clone()));
             }
         }
         out

--- a/src/typesetting.rs
+++ b/src/typesetting.rs
@@ -8,8 +8,9 @@
 
 use crate::{
     diag::Diagnostic,
-    parser::{as_str, StatementAddress, Token},
+    parser::{as_str, StatementAddress, Token, TokenPtr},
 };
+use std::collections::HashMap;
 
 /// The parsed `$t` comment data.
 #[derive(Debug, Default, Clone)]
@@ -22,7 +23,7 @@ pub struct TypesettingData {
     /// ```text
     /// latexdef "ph" as "\varphi";
     /// ```
-    pub latex_defs: Vec<(Token, Token)>,
+    pub latex_defs: HashMap<Token, Token>,
 
     /// HTML definitions are used to replace a token with a piece of HTML syntax.
     /// This version will generally be used for the GIF rendering version of the web pages.
@@ -30,7 +31,7 @@ pub struct TypesettingData {
     /// ```text
     /// htmldef "ph" as "<IMG SRC='_varphi.gif' WIDTH=11 HEIGHT=19 ALT=' ph' TITLE='ph'>";
     /// ```
-    pub html_defs: Vec<(Token, Token)>,
+    pub html_defs: HashMap<Token, Token>,
 
     /// HTML definitions are used to replace a token with a piece of HTML syntax.
     /// This version will generally be used for the unicode rendering version of the web pages.
@@ -38,7 +39,7 @@ pub struct TypesettingData {
     /// ```text
     /// althtmldef "ph" as "<SPAN CLASS=wff STYLE='color:blue'>&#x1D711;</SPAN>";
     /// ```
-    pub alt_html_defs: Vec<(Token, Token)>,
+    pub alt_html_defs: HashMap<Token, Token>,
 
     /// A piece of HTML to give the variable color key. All `htmlvarcolor` directives are given
     /// separately here, but they are logically concatenated with spaces for rendering.
@@ -147,6 +148,12 @@ pub struct TypesettingData {
 }
 
 impl TypesettingData {
+    /// Get the unicode rendering for a given symbol
+    #[must_use]
+    pub fn get_alt_html_def(&self, symbol: TokenPtr<'_>) -> Option<&Token> {
+        self.alt_html_defs.get(symbol)
+    }
+
     /// Dump the content of this outline to the standard output
     pub(crate) fn dump(&self) {
         for v in &self.html_var_color {

--- a/src/typesetting.rs
+++ b/src/typesetting.rs
@@ -1,0 +1,192 @@
+//! The typesetting data.
+//!
+//! This is the result of parsing a `$t` metamath comment, which contains information
+//! used by the metamath website generator. Although `metamath-knife` tries to be
+//! generic and so it does not itself contain a website generator, this pass can be
+//! used to collect information for generating HTML in the style of
+//! [`metamath.exe`](https://github.com/metamath/metamath-exe).
+
+use crate::parser::{as_str, Token};
+
+/// The parsed `$t` comment data.
+#[derive(Debug, Default, Clone)]
+pub struct TypesettingData {
+    /// LaTeX definitions are used to replace a token with a piece of latex syntax.
+    /// Each entry has the form `(token, replacement)`.
+    /// ```text
+    /// latexdef "ph" as "\varphi";
+    /// ```
+    pub latex_defs: Vec<(Token, Token)>,
+
+    /// HTML definitions are used to replace a token with a piece of HTML syntax.
+    /// This version will generally be used for the GIF rendering version of the web pages.
+    /// Each entry has the form `(token, replacement)`.
+    /// ```text
+    /// htmldef "ph" as "<IMG SRC='_varphi.gif' WIDTH=11 HEIGHT=19 ALT=' ph' TITLE='ph'>";
+    /// ```
+    pub html_defs: Vec<(Token, Token)>,
+
+    /// HTML definitions are used to replace a token with a piece of HTML syntax.
+    /// This version will generally be used for the unicode rendering version of the web pages.
+    /// Each entry has the form `(token, replacement)`.
+    /// ```text
+    /// althtmldef "ph" as "<SPAN CLASS=wff STYLE='color:blue'>&#x1D711;</SPAN>";
+    /// ```
+    pub alt_html_defs: Vec<(Token, Token)>,
+
+    /// A piece of HTML to give the variable color key. All `htmlvarcolor` directives are given
+    /// separately here, but they are logically concatenated with spaces for rendering.
+    /// ```text
+    /// htmlvarcolor '<SPAN CLASS=wff STYLE="color:blue;font-style:normal">wff</SPAN> '
+    ///   + '<SPAN CLASS=setvar STYLE="color:red;font-style:normal">setvar</SPAN> '
+    ///   + '<SPAN CLASS=class STYLE="color:#C3C;font-style:normal">class</SPAN>';
+    /// ```
+    pub html_var_color: Vec<Token>,
+
+    /// The title of the generated HTML page.
+    /// ```text
+    /// htmltitle "Metamath Proof Explorer";
+    /// ```
+    pub html_title: Option<Token>,
+
+    /// The link to the home page in the generated HTML page.
+    /// ```text
+    /// htmlhome '<A HREF="mmset.html"><FONT SIZE=-2 FACE=sans-serif>' +
+    ///     '<IMG SRC="mm.gif" BORDER=0 ALT='  +
+    ///     '"Home" HEIGHT=32 WIDTH=32 ALIGN=MIDDLE STYLE="margin-bottom:0px">' +
+    ///     'Home</FONT></A>';
+    /// ```
+    pub html_home: Option<Token>,
+
+    /// The relative path from the unicode version to the GIF version. Used for cross references.
+    /// (This is a set.mm specific hack.)
+    /// ```text
+    /// htmldir "../mpegif/";
+    /// ```
+    pub html_dir: Option<Token>,
+
+    /// The relative path from the GIF version to the unicode version. Used for cross references.
+    /// (This is a set.mm specific hack.)
+    /// ```text
+    /// althtmldir "../mpeuni/";
+    /// ```
+    pub alt_html_dir: Option<Token>,
+
+    /// Optional file where bibliographic references are kept.
+    /// ```text
+    /// htmlbibliography "mmset.html";
+    /// ```
+    pub html_bibliography: Option<Token>,
+
+    /// Custom CSS to be placed in the header of generated files.
+    /// Note that any `\n` escapes are not yet replaced by newlines in this `html_css` variable;
+    /// library consumers are responsible for performing this replacement.
+    /// ```text
+    /// htmlcss '<STYLE TYPE="text/css">\n' +
+    ///   '</STYLE>\n' +
+    ///   '<LINK href="mmset.css" title="mmset"\n' +
+    ///   '    rel="stylesheet" type="text/css">\n';
+    /// ```
+    pub html_css: Option<Token>,
+
+    /// Tag(s) for the main SPAN surrounding all Unicode math.
+    /// ```text
+    /// htmlfont 'CLASS=math';
+    /// ```
+    pub html_font: Option<Token>,
+
+    /// A label, such that everything after this label uses the `ext_*` variables instead of the
+    /// regular ones.
+    /// (This is a set.mm specific hack.)
+    /// ```text
+    /// exthtmllabel "chil";
+    /// ```
+    pub ext_html_label: Option<Token>,
+
+    /// The title of the generated HTML page, for the Hilbert Space extension.
+    /// (This is a set.mm specific hack.)
+    /// ```text
+    /// exthtmltitle "Hilbert Space Explorer";
+    /// ```
+    pub ext_html_title: Option<Token>,
+
+    /// The link to the home page in the generated HTML page, for the Hilbert Space extension.
+    /// (This is a set.mm specific hack.)
+    /// ```text
+    /// exthtmlhome '<A HREF="mmhil.html"><FONT SIZE=-2 FACE=sans-serif>' +
+    ///    '<IMG SRC="atomic.gif" BORDER=0 ALT='  +
+    ///    '"Home" HEIGHT=32 WIDTH=32 ALIGN=MIDDLE STYLE="margin-bottom:0px">' +
+    ///    'Home</FONT></A>';
+    /// ```
+    pub ext_html_home: Option<Token>,
+
+    /// Optional file where bibliographic references are kept, for the Hilbert Space extension.
+    /// (This is a set.mm specific hack.)
+    /// ```text
+    /// exthtmlbibliography "mmhil.html";
+    /// ```
+    pub ext_html_bibliography: Option<Token>,
+
+    /// Optional link(s) to other versions of the theorem page.  A "*" is replaced
+    /// with the label of the current theorem.  If you need a literal "*" as part
+    /// of the URL, use the alternate URL encoding "%2A". (Note that `*` characters are not
+    /// interpreted in this string; library consumers are responsible for implementing this spec.)
+    /// ```text
+    /// htmlexturl '<A HREF="http://metamath.tirix.org/*.html">'
+    ///     + 'Structured version</A>&nbsp;&nbsp; '
+    ///     + '<A HREF="https://expln.github.io/metamath/asrt/*.html">'
+    ///     + 'Visualization version</A>&nbsp;&nbsp; ';
+    /// ```
+    pub html_ext_url: Option<Token>,
+}
+
+impl TypesettingData {
+    /// Dump the content of this outline to the standard output
+    pub(crate) fn dump(&self) {
+        for v in &self.html_var_color {
+            println!("html_var_color += {:?};", as_str(v));
+        }
+        println!("html_title = {:?};", self.html_title.as_deref().map(as_str));
+        println!("html_home = {:?};", self.html_home.as_deref().map(as_str));
+        println!("html_dir = {:?};", self.html_dir.as_deref().map(as_str));
+        println!(
+            "alt_html_dir = {:?};",
+            self.alt_html_dir.as_deref().map(as_str)
+        );
+        println!(
+            "html_bibliography = {:?};",
+            self.html_bibliography.as_deref().map(as_str)
+        );
+        println!("html_css = {:?};", self.html_css.as_deref().map(as_str));
+        println!("html_font = {:?};", self.html_font.as_deref().map(as_str));
+        println!(
+            "ext_html_label = {:?};",
+            self.ext_html_label.as_deref().map(as_str)
+        );
+        println!(
+            "ext_html_title = {:?};",
+            self.ext_html_title.as_deref().map(as_str)
+        );
+        println!(
+            "ext_html_home = {:?};",
+            self.ext_html_home.as_deref().map(as_str)
+        );
+        println!(
+            "ext_html_bibliography = {:?};",
+            self.ext_html_bibliography.as_deref().map(as_str)
+        );
+        println!(
+            "html_ext_url = {:?};",
+            self.html_ext_url.as_deref().map(as_str)
+        );
+        for (tk, v) in &self.latex_defs {
+            println!("latex_defs[{:?}] = {:?};", as_str(tk), as_str(v));
+        }
+        for (tk, v) in &self.html_defs {
+            println!("html_defs[{:?}] = {:?};", as_str(tk), as_str(v));
+        }
+        for (tk, v) in &self.alt_html_defs {
+            println!("alt_html_defs[{:?}] = {:?};", as_str(tk), as_str(v));
+        }
+    }
+}

--- a/src/typesetting.rs
+++ b/src/typesetting.rs
@@ -6,11 +6,17 @@
 //! used to collect information for generating HTML in the style of
 //! [`metamath.exe`](https://github.com/metamath/metamath-exe).
 
-use crate::parser::{as_str, Token};
+use crate::{
+    diag::Diagnostic,
+    parser::{as_str, StatementAddress, Token},
+};
 
 /// The parsed `$t` comment data.
 #[derive(Debug, Default, Clone)]
 pub struct TypesettingData {
+    /// Any errors detected while parsing this segment.
+    pub diagnostics: Vec<(StatementAddress, Diagnostic)>,
+
     /// LaTeX definitions are used to replace a token with a piece of latex syntax.
     /// Each entry has the form `(token, replacement)`.
     /// ```text


### PR DESCRIPTION
This extends the `$j` command parser a bit to handle the contents of the `$t` comment, and adds a complete parser for `$t` commands. I'm thinking about writing a web site generator, but I'm not sure whether all the metamath hacks belong in this repo, so maybe it should just be a separate crate (and/or repo) which uses this library for parsing.