### PR TITLE
add comment markup parser

### DIFF
--- a/src/comment_parser.rs
+++ b/src/comment_parser.rs
@@ -1,0 +1,379 @@
+//! Implements markup parsing for metamath theorem comments.
+//!
+//! The [set.mm](https://github.com/metamath/set.mm/) library contains many
+//! theorems with comments, and those comments contain markup in a special syntax
+//! implemented by [metamath.exe](https://github.com/metamath/metamath-exe).
+//! This module implements a SAX-style parser which yields events about the
+//! beginning and end of each syntax event.
+//!
+//! The [`CommentItem`] type does not contain any byte buffers directly;
+//! instead everything uses spans relative to the segment in which this comment
+//! appeared. Note that for many of the [`Span`]-containing fields the
+//! corresponding byte string in the file has to be unescaped before
+//! interpretation, using the [`CommentParser::unescape_text`] and
+//! [`CommentParser::unescape_math`] functions.
+use crate::parser::Span;
+
+/// A comment markup item, which represents either a piece of text from the input
+/// or some kind of metadata item like the start or end of an italicized group.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommentItem {
+    /// A piece of regular text. The characters in the buffer at the given
+    /// span should be interpreted literally, except for the escapes.
+    /// Use `unescape_text` to strip the text escapes.
+    Text(Span),
+    /// A paragraph break, caused by two or more consecutive newlines in the input.
+    /// This is a zero-length item (all characters will be present in `Text` nodes
+    /// before and after the element), but corresponds roughly to a `<p>` tag in HTML.
+    LineBreak(usize),
+    /// Start math mode, indicated by a backtick character. The usize points to the character.
+    /// Between [`StartMathMode`] and [`EndMathMode`],
+    /// there will be no comment items other than [`MathToken`] and [`Escaped`].
+    StartMathMode(usize),
+    /// End math mode, indicated by a backtick character. The usize points to the character.
+    /// Between [`StartMathMode`] and [`EndMathMode`],
+    /// there will be no comment items other than [`MathToken`] and [`Escaped`].
+    EndMathMode(usize),
+    /// A single math token. Beware that [`Escaped`] can split a math token,
+    /// so this may not correspond to a `$c` or `$v` token directly.
+    /// Use `unescape_math` to strip the escapes.
+    MathToken(Span),
+    /// A label of an existing theorem. The `usize` points to the `~` character.
+    /// Use `unescape_text` to strip the text escapes.
+    Label(usize, Span),
+    /// A link to a web site URL. The `usize` points to the `~` character.
+    /// Use `unescape_text` to strip the text escapes.
+    Url(usize, Span),
+    /// The `<HTML>` keyword, which starts HTML mode
+    /// (it doesn't actually put `<HTML>` in the output).
+    /// In HTML mode subscripts and italics are disabled, and HTML markup is interpreted.
+    StartHtml(usize),
+    /// The `</HTML>` keyword, which ends HTML mode
+    /// (it doesn't actually put `</HTML>` in the output).
+    EndHtml(usize),
+    /// The start of a subscript `x_0`. The `usize` points at the `_` character.
+    StartSubscript(usize),
+    /// The end of a subscript like `x_0`. The `usize` points just after the end of the word.
+    EndSubscript(usize),
+    /// The start of an italic section `_italic text_`. The `usize` points at the `_` character.
+    StartItalic(usize),
+    /// The end of an italic section `_italic text_`. The `usize` points at the `_` character.
+    EndItalic(usize),
+    /// A bibliographic label `[foo]`. No escapes are needed inside the tag body.
+    BibTag(Span),
+}
+
+impl CommentItem {
+    /// Remove text escapes from a markup segment `buf`, generally coming from the
+    /// [`CommentItem::Text`], [`CommentItem::Label`], or [`CommentItem::Url`] fields.
+    pub fn unescape_text(buf: &[u8], out: &mut Vec<u8>) {
+        let mut iter = buf.iter();
+        while let Some(&c) = iter.next() {
+            match c {
+                b'`' | b'[' | b'~' => {
+                    iter.next();
+                }
+                _ => out.push(c),
+            }
+        }
+    }
+
+    /// Remove math escapes from a markup segment `buf`, generally coming from the
+    /// [`CommentItem::MathToken`] field.
+    pub fn unescape_math(buf: &[u8], out: &mut Vec<u8>) {
+        let mut iter = buf.iter();
+        while let Some(&c) = iter.next() {
+            match c {
+                b'`' => {
+                    iter.next();
+                }
+                _ => out.push(c),
+            }
+        }
+    }
+
+    const fn token(math: bool, span: Span) -> Self {
+        if math {
+            Self::MathToken(span)
+        } else {
+            Self::Text(span)
+        }
+    }
+}
+
+/// An iterator over a metamath text comment, yielding markup items.
+#[derive(Debug, Clone)]
+pub struct CommentParser<'a> {
+    buf: &'a [u8],
+    pos: usize,
+    math_mode: bool,
+    html_mode: bool,
+    item: Option<CommentItem>,
+    end_italic: usize,
+    end_subscript: usize,
+}
+
+impl<'a> CommentParser<'a> {
+    /// Construct a new `CommentParser` from a sub-span of a buffer.
+    /// The returned comment items will have spans based on the input span,
+    /// and the portion of the buffer outside `buf[span.start..span.end]` will be ignored.
+    #[must_use]
+    pub fn new(buf: &'a [u8], span: Span) -> Self {
+        Self {
+            buf: &buf[..span.end as usize],
+            pos: span.start as _,
+            math_mode: false,
+            html_mode: false,
+            item: None,
+            end_italic: usize::MAX,
+            end_subscript: 0,
+        }
+    }
+
+    /// Remove text escapes from a markup segment `span`, generally coming from the
+    /// [`CommentItem::Text`], [`CommentItem::Label`], or [`CommentItem::Url`] fields.
+    pub fn unescape_text(&self, span: Span, out: &mut Vec<u8>) {
+        CommentItem::unescape_text(span.as_ref(self.buf), out)
+    }
+
+    /// Remove math escapes from a markup segment `span`, generally coming from the
+    /// [`CommentItem::MathToken`] field.
+    pub fn unescape_math(&self, span: Span, out: &mut Vec<u8>) {
+        CommentItem::unescape_math(span.as_ref(self.buf), out)
+    }
+
+    fn parse_bib(&self) -> Option<Span> {
+        let start = self.pos + 1;
+        let mut end = start;
+        loop {
+            if let Some(&c) = self.buf.get(end) {
+                if c == b']' {
+                    return Some(Span::new(start, end));
+                }
+                if !c.is_ascii_whitespace() {
+                    end += 1;
+                    continue;
+                }
+            }
+            return None;
+        }
+    }
+
+    fn is_subscript(&self) -> Option<()> {
+        const OPENING_PUNCTUATION: &[u8] = b"(['\"";
+        if self.pos == self.end_subscript {
+            return None;
+        }
+        let c = self.buf.get(self.pos.checked_sub(1)?)?;
+        if c.is_ascii_whitespace() || OPENING_PUNCTUATION.contains(c) {
+            return None;
+        }
+        Some(())
+    }
+
+    fn parse_subscript(&self) -> Option<usize> {
+        const CLOSING_PUNCTUATION: &[u8] = b".,;)?!:]'\"_-";
+        let c = self.buf.get(self.pos + 1)?;
+        if c.is_ascii_whitespace() || CLOSING_PUNCTUATION.contains(c) {
+            return None;
+        }
+        let start = self.pos + 1;
+        let mut end = start;
+        while let Some(c) = self.buf.get(end) {
+            if c.is_ascii_whitespace() || CLOSING_PUNCTUATION.contains(c) {
+                break;
+            }
+            end += 1;
+        }
+        Some(end)
+    }
+
+    fn parse_italic(&self) -> Option<usize> {
+        if !self.buf.get(self.pos + 1)?.is_ascii_alphanumeric() {
+            return None;
+        }
+        let end = (self.pos + 2) + self.buf[self.pos + 2..].iter().position(|&c| c == b'_')?;
+        if !self.buf[end - 1].is_ascii_alphanumeric()
+            || matches!(self.buf.get(end + 1), Some(c) if c.is_ascii_alphanumeric())
+        {
+            return None;
+        }
+        Some(end)
+    }
+
+    fn parse_underscore(&mut self) -> Option<(usize, CommentItem)> {
+        let start = self.pos;
+        let item = if self.is_subscript().is_some() {
+            let sub_end = self.parse_subscript()?;
+            self.pos += 1;
+            self.end_subscript = sub_end;
+            CommentItem::StartSubscript(start)
+        } else {
+            let it_end = self.parse_italic()?;
+            self.pos += 1;
+            self.end_italic = it_end;
+            CommentItem::StartItalic(start)
+        };
+        Some((start, item))
+    }
+
+    fn parse_html(&mut self) -> Option<(usize, CommentItem)> {
+        if self.html_mode {
+            if self.buf[self.pos..].starts_with(b"</HTML>") {
+                self.html_mode = false;
+                let start = self.pos;
+                self.pos += 7;
+                Some((start, CommentItem::EndHtml(start)))
+            } else {
+                None
+            }
+        } else if self.buf[self.pos..].starts_with(b"<HTML>") {
+            self.html_mode = true;
+            let start = self.pos;
+            self.pos += 6;
+            Some((start, CommentItem::StartHtml(start)))
+        } else {
+            None
+        }
+    }
+
+    fn parse_math_delim(&mut self, at: usize) -> CommentItem {
+        if self.math_mode {
+            self.math_mode = false;
+            CommentItem::EndMathMode(at)
+        } else {
+            self.math_mode = true;
+            CommentItem::StartMathMode(at)
+        }
+    }
+
+    fn skip_whitespace(&mut self) {
+        while matches!(self.buf.get(self.pos), Some(c) if c.is_ascii_whitespace()) {
+            self.pos += 1;
+        }
+    }
+
+    fn parse_newline(&self, last_nl: Option<usize>) -> Option<()> {
+        self.buf[last_nl? + 1..self.pos]
+            .iter()
+            .all(u8::is_ascii_whitespace)
+            .then(|| ())
+    }
+
+    fn parse_label(&mut self) -> CommentItem {
+        let tilde = self.pos;
+        self.pos += 1;
+        while matches!(self.buf.get(self.pos), Some(c) if c.is_ascii_whitespace()) {
+            self.pos += 1;
+        }
+        let label_start = self.pos;
+        while matches!(self.buf.get(self.pos), Some(c) if !c.is_ascii_whitespace()) {
+            self.pos += 1;
+        }
+        let label = &self.buf[label_start..self.pos];
+        if label.starts_with(b"http://")
+            || label.starts_with(b"https://")
+            || label.starts_with(b"mm")
+        {
+            CommentItem::Url(tilde, Span::new(label_start, self.pos))
+        } else {
+            CommentItem::Label(tilde, Span::new(label_start, self.pos))
+        }
+    }
+}
+
+impl<'a> Iterator for CommentParser<'a> {
+    type Item = CommentItem;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(item) = self.item.take() {
+            return Some(item);
+        }
+        let math_token = self.math_mode;
+        if math_token {
+            self.skip_whitespace()
+        }
+        let start = self.pos;
+        let mut end = self.buf.len();
+        let mut last_nl = None;
+        while let Some(&c) = self.buf.get(self.pos) {
+            if c == b'`' {
+                if self.buf.get(self.pos + 1) == Some(&b'`') {
+                    self.pos += 2;
+                } else {
+                    end = self.pos;
+                    self.pos += 1;
+                    self.item = Some(self.parse_math_delim(end));
+                    break;
+                }
+            } else if math_token {
+                if matches!(self.buf.get(self.pos), Some(c) if !c.is_ascii_whitespace()) {
+                    self.pos += 1;
+                } else if self.pos > start {
+                    return Some(CommentItem::MathToken(Span::new(start, self.pos)));
+                } else {
+                    return None;
+                }
+            } else if c == b'<' {
+                if let Some((start, item)) = self.parse_html() {
+                    end = start;
+                    self.item = Some(item);
+                    break;
+                }
+                self.pos += 1;
+            } else if c == b'~' {
+                if self.buf.get(self.pos + 1) == Some(&b'~') {
+                    self.pos += 2;
+                } else {
+                    end = self.pos;
+                    self.item = Some(self.parse_label());
+                    break;
+                }
+            } else if c == b'[' {
+                if self.buf.get(self.pos + 1) == Some(&b'[') {
+                    self.pos += 2;
+                } else if let Some(span) = self.parse_bib() {
+                    end = self.pos;
+                    self.pos = span.end as usize + 1;
+                    self.item = Some(CommentItem::BibTag(span));
+                    break;
+                } else {
+                    self.pos += 1;
+                }
+            } else if self.html_mode {
+                self.pos += 1;
+            } else if c == b'\n' {
+                if self.parse_newline(last_nl.replace(self.pos)).is_some() {
+                    end = self.pos;
+                    self.item = Some(CommentItem::LineBreak(end));
+                    break;
+                }
+                self.pos += 1;
+            } else if c == b'_' {
+                if self.end_italic == self.pos {
+                    end = self.pos;
+                    self.pos += 1;
+                    self.item = Some(CommentItem::EndItalic(end));
+                    break;
+                }
+                if let Some((pos, item)) = self.parse_underscore() {
+                    end = pos;
+                    self.item = Some(item);
+                    break;
+                }
+                self.pos += 1;
+            } else {
+                self.pos += 1;
+            }
+            if self.pos == self.end_subscript {
+                end = self.pos;
+                self.item = Some(CommentItem::EndSubscript(end));
+                break;
+            }
+        }
+        if end > start {
+            return Some(CommentItem::token(math_token, Span::new(start, end)));
+        }
+        self.item.take()
+    }
+}

--- a/src/comment_parser.rs
+++ b/src/comment_parser.rs
@@ -36,8 +36,8 @@ pub enum CommentItem {
     /// Between [`StartMathMode`] and [`EndMathMode`],
     /// there will be no comment items other than [`MathToken`].
     EndMathMode(usize),
-    /// A single math token. Beware that [`Escaped`] can split a math token,
-    /// so this may not correspond to a `$c` or `$v` token directly.
+    /// A single math token. After unescaping this should correspond to a `$c` or `$v` statement
+    /// in the database.
     /// Use `unescape_math` to strip the escapes.
     MathToken(Span),
     /// A label of an existing theorem. The `usize` points to the `~` character.

--- a/src/comment_parser_tests.rs
+++ b/src/comment_parser_tests.rs
@@ -1,0 +1,203 @@
+use crate::{
+    comment_parser::{
+        CommentItem::{self, *},
+        CommentParser,
+    },
+    parser::Span,
+};
+
+#[track_caller]
+fn check(buf: &[u8], expected: &[CommentItem]) {
+    assert_eq!(
+        CommentParser::new(buf, Span::new(0, buf.len())).collect::<Vec<_>>(),
+        expected
+    )
+}
+
+#[test]
+fn test_basic() {
+    check(b"Hello world", &[Text(Span::new(0, 11))]);
+}
+
+#[test]
+fn test_subscript() {
+    check(
+        b"Hello_world test",
+        &[
+            Text(Span::new(0, 5)),
+            StartSubscript(5),
+            Text(Span::new(6, 11)),
+            EndSubscript(11),
+            Text(Span::new(11, 16)),
+        ],
+    );
+}
+
+/// Metamath does not support nested subscripts, because `_` counts as a closing delimiter.
+/// This turns into `x₀_y`.
+#[test]
+fn test_two_subscript() {
+    check(
+        b"x_0_y",
+        &[
+            Text(Span::new(0, 1)),
+            StartSubscript(1),
+            Text(Span::new(2, 3)),
+            EndSubscript(3),
+            Text(Span::new(3, 5)),
+        ],
+    );
+}
+
+/// You can have two subscripts in one word: `x₀_y₁`
+#[test]
+fn test_three_subscript() {
+    check(
+        b"x_0_y_1",
+        &[
+            Text(Span::new(0, 1)),
+            StartSubscript(1),
+            Text(Span::new(2, 3)),
+            EndSubscript(3),
+            Text(Span::new(3, 5)),
+            StartSubscript(5),
+            Text(Span::new(6, 7)),
+            EndSubscript(7),
+        ],
+    );
+}
+
+#[test]
+fn test_italic() {
+    check(
+        b"a _b_ c",
+        &[
+            Text(Span::new(0, 2)),
+            StartItalic(2),
+            Text(Span::new(3, 4)),
+            EndItalic(4),
+            Text(Span::new(5, 7)),
+        ],
+    );
+
+    check(
+        b"a _b c_ d",
+        &[
+            Text(Span::new(0, 2)),
+            StartItalic(2),
+            Text(Span::new(3, 6)),
+            EndItalic(6),
+            Text(Span::new(7, 9)),
+        ],
+    );
+}
+
+#[test]
+fn test_bib() {
+    check(
+        b"Hello [world] test",
+        &[
+            Text(Span::new(0, 6)),
+            BibTag(Span::new(7, 12)),
+            Text(Span::new(13, 18)),
+        ],
+    );
+    check(
+        b"_italic [bib] test_",
+        &[
+            StartItalic(0),
+            Text(Span::new(1, 8)),
+            BibTag(Span::new(9, 12)),
+            Text(Span::new(13, 18)),
+            EndItalic(18),
+        ],
+    );
+    check(b"[failed bib] test", &[Text(Span::new(0, 17))]);
+    check(b"[[escaped] bib", &[Text(Span::new(0, 14))]);
+}
+
+#[test]
+fn test_math() {
+    check(
+        b"` [x] + y_1 ` z_1",
+        &[
+            StartMathMode(0),
+            MathToken(Span::new(2, 5)),
+            MathToken(Span::new(6, 7)),
+            MathToken(Span::new(8, 11)),
+            EndMathMode(12),
+            Text(Span::new(13, 15)),
+            StartSubscript(15),
+            Text(Span::new(16, 17)),
+            EndSubscript(17),
+        ],
+    );
+    check(
+        b"`no spaces`",
+        &[
+            StartMathMode(0),
+            MathToken(Span::new(1, 3)),
+            MathToken(Span::new(4, 10)),
+            EndMathMode(10),
+        ],
+    );
+}
+
+#[test]
+fn test_label() {
+    check(
+        b"See ~ my_thm",
+        &[Text(Span::new(0, 4)), Label(4, Span::new(6, 12))],
+    );
+    check(
+        b"Visit ~http://example.com",
+        &[Text(Span::new(0, 6)), Url(6, Span::new(7, 25))],
+    );
+}
+
+#[test]
+fn test_html() {
+    check(
+        b"Inside <HTML> tags, ~ labels work but sub_scripts don't </HTML>.",
+        &[
+            Text(Span::new(0, 7)),
+            StartHtml(7),
+            Text(Span::new(13, 20)),
+            Label(20, Span::new(22, 28)),
+            Text(Span::new(28, 56)),
+            EndHtml(56),
+            Text(Span::new(63, 64)),
+        ],
+    );
+    check(
+        b"It is an error to not close <HTML> tags",
+        &[
+            Text(Span::new(0, 28)),
+            StartHtml(28),
+            Text(Span::new(34, 39)),
+        ],
+    );
+}
+#[test]
+fn test_para() {
+    check(
+        b"Line 1\n\nLine 2\n\nLine 3",
+        &[
+            Text(Span::new(0, 7)),
+            LineBreak(7),
+            Text(Span::new(7, 15)),
+            LineBreak(15),
+            Text(Span::new(15, 22)),
+        ],
+    );
+    check(
+        b"Extra\n\n\nWide",
+        &[
+            Text(Span::new(0, 6)),
+            LineBreak(6),
+            Text(Span::new(6, 7)),
+            LineBreak(7),
+            Text(Span::new(7, 12)),
+        ],
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ mod segment_set;
 mod tree;
 mod util;
 
+pub mod comment_parser;
 pub mod database;
 pub mod diag;
 pub mod export;
@@ -68,6 +69,8 @@ pub mod scopeck;
 pub mod typesetting;
 pub mod verify;
 
+#[cfg(test)]
+mod comment_parser_tests;
 #[cfg(test)]
 mod formula_tests;
 #[cfg(test)]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -45,6 +45,7 @@
 //! `SegmentId` and `SegmentRef` cover the same use cases for segments, although
 //! it makes no sense to have a segment-local segment reference.
 
+use crate::comment_parser::CommentParser;
 use crate::diag::Diagnostic;
 use crate::segment_set::SegmentSet;
 use crate::typesetting::TypesettingData;
@@ -908,6 +909,24 @@ impl<'a> StatementRef<'a> {
         } else {
             None
         }
+    }
+
+    /// The contents of a comment statement, excluding the `$(` and `$)` delimiters,
+    /// and trimming an extra space from the trailing delimiter.
+    /// (We can't trim both sides without extra checks, because it would double count
+    /// the middle space in `$( $)`.)
+    #[must_use]
+    pub const fn comment_contents(&self) -> Span {
+        Span::new2(self.statement.label.start + 2, self.span_full().end - 3)
+    }
+
+    /// The contents of a comment statement, excluding the `$(` and `$)` delimiters,
+    /// and trimming an extra space from the trailing delimiter.
+    /// (We can't trim both sides without extra checks, because it would double count
+    /// the middle space in `$( $)`.)
+    #[must_use]
+    pub fn comment_parser(&self) -> CommentParser<'a> {
+        CommentParser::new(&self.segment.segment.buffer, self.comment_contents())
     }
 }
 


### PR DESCRIPTION
This lets us parse metamath's pseudo-markdown syntax in comments:

```
$( You can do _italics_, sub_scripts, <HTML>(basically <B>verbatim</b>)</HTML> blocks,
   ~ label references and ~ http://web-site.com references, and ` ( math + strings ) ` .
  
   Also paragraph breaks and [Biblio] references.
  
   This last bit is not parsed, these markers are handled separately from markup parsing:
   (Contributed by Mario Carneiro, 28-Jan-2022.) $)
foo $a |- ( ph -> ph ) $.
```