### PR TITLE
add verify markup pass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1defb949b123415131ecae40ab5dca70e9f39eedda3de2cebb03a8a98fdf5894"
 
 [[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
 name = "filetime"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -129,6 +135,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -167,6 +182,7 @@ dependencies = [
  "dot-writer",
  "filetime",
  "fnv",
+ "itertools",
  "lazy_static",
  "log",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,11 @@ description = "A parallel and incremental verifier for Metamath databases"
 repository = "https://github.com/david-a-wheeler/metamath-knife"
 keywords = ["theorem", "proving", "verifier", "proof", "assistant"]
 categories = ["command-line-utilities", "development-tools", "mathematics"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 lazy_static = "1.4"
+itertools = "0.10"
 filetime = "0.2"
 fnv = "1.0"
 regex = "1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ lazy_static = "1.4"
 itertools = "0.10"
 filetime = "0.2"
 fnv = "1.0"
-regex = "1.5"
+regex = { version = "1.5", default-features = false, features = ["std", "perf"] }
 tinyvec = "1.5"
 log = "0.4"
 annotate-snippets = "0.9"

--- a/src/comment_parser.rs
+++ b/src/comment_parser.rs
@@ -170,18 +170,16 @@ impl<'a> CommentParser<'a> {
     fn parse_bib(&self) -> Option<Span> {
         let start = self.pos + 1;
         let mut end = start;
-        loop {
-            if let Some(&c) = self.buf.get(end) {
-                if c == b']' {
-                    return Some(Span::new(start, end));
-                }
-                if !c.is_ascii_whitespace() {
-                    end += 1;
-                    continue;
-                }
+        while let Some(&c) = self.buf.get(end) {
+            match c {
+                b']' => return Some(Span::new(start, end)),
+                b'`' if self.buf.get(end + 1) == Some(&c) => end += 2,
+                b'`' => break,
+                _ if c.is_ascii_whitespace() => break,
+                _ => end += 1,
             }
-            return None;
         }
+        None
     }
 
     fn is_subscript(&self) -> Option<()> {

--- a/src/comment_parser.rs
+++ b/src/comment_parser.rs
@@ -14,6 +14,8 @@
 //! corresponding byte string in the file has to be unescaped before
 //! interpretation, using the [`CommentParser::unescape_text`] and
 //! [`CommentParser::unescape_math`] functions.
+use std::fmt::Display;
+
 use lazy_static::lazy_static;
 use regex::bytes::{CaptureMatches, Match, Regex, RegexSet};
 
@@ -540,11 +542,26 @@ impl<'a> Iterator for ParentheticalIter<'a> {
 #[derive(Debug, Copy, Clone, PartialOrd, Ord, PartialEq, Eq)]
 pub struct Date {
     /// A year, which must be a 4 digit number (0-9999).
-    pub year: u32,
+    pub year: u16,
     /// A month, parsed from three letter names: `Jan`, `Feb`, etc. (1-12)
     pub month: u8,
     /// A day, parsed from a 1 or 2 digit number (0-99).
     pub day: u8,
+}
+
+impl Display for Date {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        const MONTHS: [&str; 12] = [
+            "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+        ];
+        write!(
+            f,
+            "{day}-{month}-{year:04}",
+            day = self.day,
+            month = MONTHS[(self.month - 1) as usize],
+            year = self.year
+        )
+    }
 }
 
 impl TryFrom<&[u8]> for Date {

--- a/src/comment_parser_tests.rs
+++ b/src/comment_parser_tests.rs
@@ -164,6 +164,27 @@ fn edge_cases() {
             MathToken(Span::new(2, 3)),
         ],
     );
+    check(
+        b"` a `_2",
+        &[
+            StartMathMode(0),
+            MathToken(Span::new(2, 3)),
+            EndMathMode(4),
+            StartSubscript(5),
+            Text(Span::new(6, 7)),
+            EndSubscript(7),
+        ],
+    );
+    check(
+        b"` a ` _2",
+        &[
+            StartMathMode(0),
+            MathToken(Span::new(2, 3)),
+            EndMathMode(4),
+            Text(Span::new(5, 8)),
+        ],
+    );
+
     check(b"~<HTML>", &[Label(0, Span::new(1, 1)), StartHtml(1)]);
     check(
         b"~</HTML>",

--- a/src/comment_parser_tests.rs
+++ b/src/comment_parser_tests.rs
@@ -146,6 +146,32 @@ fn test_math() {
 }
 
 #[test]
+fn edge_cases() {
+    check(b"[", &[Text(Span::new(0, 1))]);
+    check(b"~", &[Label(0, Span::new(1, 1))]);
+    check(b"`", &[StartMathMode(0)]);
+    check(b"~[x", &[Label(0, Span::new(1, 3))]);
+    check(b"~[[x]", &[Label(0, Span::new(1, 5))]);
+    check(
+        b"~[x]",
+        &[Label(0, Span::new(1, 1)), BibTag(Span::new(2, 3))],
+    );
+    check(
+        b"~`x",
+        &[
+            Label(0, Span::new(1, 1)),
+            StartMathMode(1),
+            MathToken(Span::new(2, 3)),
+        ],
+    );
+    check(b"~<HTML>", &[Label(0, Span::new(1, 1)), StartHtml(1)]);
+    check(
+        b"~</HTML>",
+        &[Label(0, Span::new(1, 1)), Text(Span::new(1, 8))],
+    );
+}
+
+#[test]
 fn test_label() {
     check(
         b"See ~ my_thm",

--- a/src/database.rs
+++ b/src/database.rs
@@ -119,6 +119,7 @@ use crate::statement::StatementAddress;
 use crate::typesetting::TypesettingData;
 use crate::verify;
 use crate::verify::VerifyResult;
+use crate::verify_markup::VerifyMarkup;
 use crate::StatementRef;
 use annotate_snippets::snippet::Snippet;
 use std::cmp::Ordering;
@@ -906,6 +907,11 @@ impl Database {
         }
         if types.contains(&DiagnosticClass::Typesetting) {
             diags.extend(self.typesetting_pass().diagnostics.iter().cloned());
+        }
+        if types.contains(&DiagnosticClass::VerifyMarkup) {
+            self.scope_pass();
+            self.typesetting_pass();
+            diags.extend(self.verify_markup(VerifyMarkup::default()));
         }
         time(&self.options.clone(), "diag", move || {
             diag::to_annotations(self.parse_result(), &mut lc, diags, f)

--- a/src/database.rs
+++ b/src/database.rs
@@ -911,7 +911,14 @@ impl Database {
         if types.contains(&DiagnosticClass::VerifyMarkup) {
             self.scope_pass();
             self.typesetting_pass();
-            diags.extend(self.verify_markup(VerifyMarkup::default()));
+            // let file1 = std::fs::read("../mm/mmset.raw.html").unwrap();
+            // let file2 = std::fs::read("../mm/mmhil.html").unwrap();
+            // let bib = Bibliography2 {
+            //     base: Bibliography::parse(&file1, &mut vec![]),
+            //     ext: Some(Bibliography::parse(&file2, &mut vec![])),
+            // };
+            // diags.extend(self.verify_markup(VerifyMarkup::default(), Some(&bib)));
+            diags.extend(self.verify_markup(VerifyMarkup::default(), None));
         }
         time(&self.options.clone(), "diag", move || {
             diag::to_annotations(self.parse_result(), &mut lc, diags, f)

--- a/src/diag.rs
+++ b/src/diag.rs
@@ -211,6 +211,7 @@ pub enum Diagnostic {
     UnclosedMathMarkup(u32, u32),
     UnclosedProof,
     UnconventionalAxiomLabel(Span),
+    UndefinedBibTag(Span),
     UndefinedToken(Span, Token),
     UninterpretedEscape(u32),
     UninterpretedHtml(Span),
@@ -1070,6 +1071,12 @@ impl Diagnostic {
             UnconventionalAxiomLabel(span) => ("Unconventional axiom label".into(), vec![(
                 AnnotationType::Warning,
                 "Axioms should start with 'ax-' or 'df-'".into(),
+                stmt,
+                *span,
+            )]),
+            UndefinedBibTag(span) => ("Missing bibliography tag".into(), vec![(
+                AnnotationType::Warning,
+                "This tag was not found in the bibliography file".into(),
                 stmt,
                 *span,
             )]),

--- a/src/export.rs
+++ b/src/export.rs
@@ -76,10 +76,13 @@ impl Database {
             as_str(thm_label)
         )?;
         if let Some(comment) = stmt.associated_comment() {
+            lazy_static::lazy_static! {
+                static ref WHITESPACE: Regex = Regex::new(r"\n +").unwrap();
+            }
             let mut span = comment.span();
             span.start += 2;
             span.end -= 3;
-            let cstr = Regex::new(r"\n +").unwrap().replace_all(
+            let cstr = WHITESPACE.replace_all(
                 as_str(span.as_ref(&comment.segment().segment.buffer)),
                 "\n  ",
             );

--- a/src/export.rs
+++ b/src/export.rs
@@ -77,12 +77,12 @@ impl Database {
         )?;
         if let Some(comment) = stmt.associated_comment() {
             lazy_static::lazy_static! {
-                static ref WHITESPACE: Regex = Regex::new(r"\n +").unwrap();
+                static ref LEADING_WHITESPACE: Regex = Regex::new(r"\n +").unwrap();
             }
             let mut span = comment.span();
             span.start += 2;
             span.end -= 3;
-            let cstr = WHITESPACE.replace_all(
+            let cstr = LEADING_WHITESPACE.replace_all(
                 as_str(span.as_ref(&comment.segment().segment.buffer)),
                 "\n  ",
             );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ mod segment;
 mod segment_set;
 mod tree;
 mod util;
+mod verify_markup;
 
 pub mod comment_parser;
 pub mod database;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@
     clippy::inline_always,
     clippy::missing_errors_doc,
     clippy::module_name_repetitions,
+    clippy::needless_range_loop,
     clippy::option_if_let_else,
     clippy::redundant_pub_crate,
     clippy::semicolon_if_nothing_returned,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,6 @@ mod segment;
 mod segment_set;
 mod tree;
 mod util;
-mod verify_markup;
 
 pub mod comment_parser;
 pub mod database;
@@ -72,6 +71,7 @@ pub mod scopeck;
 pub mod statement;
 pub mod typesetting;
 pub mod verify;
+pub mod verify_markup;
 
 #[cfg(test)]
 mod comment_parser_tests;
@@ -89,6 +89,7 @@ pub use formula::Formula;
 pub use formula::FormulaRef;
 pub use formula::Label;
 pub use formula::Symbol;
+pub use segment_set::SourceInfo;
 pub use statement::as_str;
 pub use statement::Span;
 pub use statement::StatementRef;

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ fn main() {
         (@arg split: --split "Process files > 1 MiB in multiple segments")
         (@arg timing: --timing "Print milliseconds after each stage")
         (@arg verify: -v --verify "Check proof validity")
+        (@arg verify_markup: -m --("verify-markup") "Check comment markup")
         (@arg outline: -O --outline "Show database outline")
         (@arg print_typesetting: --("dump-typesetting") "Show typesetting information")
         (@arg parse_typesetting: -t --("parse-typesetting") "Parse typesetting information")
@@ -106,6 +107,10 @@ fn main() {
 
         if matches.is_present("parse_typesetting") {
             types.push(DiagnosticClass::Typesetting);
+        }
+
+        if matches.is_present("verify_markup") {
+            types.push(DiagnosticClass::VerifyMarkup);
         }
 
         if matches.is_present("verify_parse_stmt") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,8 @@ fn main() {
         (@arg jobs: -j --jobs +takes_value validator(positive_integer)
             "Number of threads to use for verification")
         (@arg export: -e --export [LABEL] ... "Output a proof file")
-        (@arg biblio: --biblio [FILE] ... "Supply a bibliography file for verify-markup")
+        (@arg biblio: --biblio [FILE] ... "Supply a bibliography file for verify-markup\n\
+            Can be used one or two times; the second is for exthtml processing")
     );
 
     #[cfg(feature = "dot")]

--- a/src/outline.rs
+++ b/src/outline.rs
@@ -19,7 +19,6 @@ use crate::tree::Tree;
 use crate::Database;
 use crate::StatementRef;
 use crate::StatementType;
-use std::cmp::Ordering;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::sync::Arc;
@@ -430,7 +429,7 @@ impl Outline {
             let mut last_node_id = node_id;
             for this_node_id in self.tree.children_iter(node_id) {
                 let node = &self.tree[this_node_id];
-                if order.cmp(&stmt_address, &node.stmt_address) == Ordering::Less {
+                if order.lt(&stmt_address, &node.stmt_address) {
                     if last_node_id == node_id {
                         return node_id;
                     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -14,17 +14,18 @@
 //! responsible for detecting includes and splitting statements appropriately,
 //! although responsibility for following includes rests on the `segment_set`.
 
-use crate::diag::Diagnostic;
+use crate::diag::{Diagnostic, MarkupKind};
 use crate::segment::{BufferRef, Segment};
 use crate::segment_set::SegmentSet;
 use crate::statement::{
-    Command, CommandToken, FilePos, FloatDef, GlobalDv, HeadingDef, LabelDef, LocalVarDef, Span,
-    Statement, StatementAddress, StatementIndex, SymbolDef, SymbolType, TokenIndex, TokenPtr,
-    NO_STATEMENT,
+    Command, CommandToken, FilePos, FloatDef, GlobalDv, GlobalSpan, HeadingDef, LabelDef,
+    LocalVarDef, Span, Statement, StatementAddress, StatementIndex, SymbolDef, SymbolType, Token,
+    TokenIndex, TokenPtr, NO_STATEMENT,
 };
 use crate::typesetting::TypesettingData;
 use crate::StatementType::{self, *};
 use std::cmp;
+use std::collections::hash_map::Entry;
 use std::fmt::Debug;
 use std::mem;
 use std::str;
@@ -997,16 +998,13 @@ impl SegmentSet {
         fn parse_one(
             data: &mut TypesettingData,
             buf: &[u8],
+            addr: StatementAddress,
             span: Span,
             command: &[CommandToken],
         ) -> Result<(), Diagnostic> {
-            fn as_string<'a>(
-                buf: &'a [u8],
-                span: Span,
-                tok: Option<&CommandToken>,
-            ) -> Result<&'a [u8], Diagnostic> {
+            const fn as_string(span: Span, tok: Option<&CommandToken>) -> Result<Span, Diagnostic> {
                 match tok {
-                    Some(&CommandToken::String(s)) => Ok(s.as_ref(buf)),
+                    Some(&CommandToken::String(s)) => Ok(s),
                     None => Err(Diagnostic::CommandIncomplete(span)),
                     Some(&CommandToken::Keyword(s)) => Err(Diagnostic::CommandExpectedString(s)),
                 }
@@ -1018,37 +1016,53 @@ impl SegmentSet {
             };
 
             let sum = |mut rest: std::slice::Iter<'_, CommandToken>| {
-                let mut accum: Vec<u8> = as_string(buf, span, rest.next())?.into();
+                let mut span_out = as_string(span, rest.next())?;
+                let mut accum: Vec<u8> = span_out.as_ref(buf).into();
+                span_out.start -= 1;
                 loop {
                     match rest.next() {
-                        None => return Ok(accum.into()),
+                        None => {
+                            span_out.end += 1;
+                            return Ok(((addr.segment_id, span_out), accum.into()));
+                        }
                         Some(CommandToken::Keyword(plus)) if plus.as_ref(buf) == b"+" => {}
                         _ => return Err(Diagnostic::CommandIncomplete(span)),
                     }
-                    accum.extend_from_slice(as_string(buf, span, rest.next())?)
+                    let span2 = as_string(span, rest.next())?;
+                    accum.extend_from_slice(span2.as_ref(buf));
+                    span_out.end = span2.end
                 }
             };
 
             let as_ = |rest: &mut std::slice::Iter<'_, CommandToken>| {
-                let s = as_string(buf, span, rest.next())?;
+                let s = as_string(span, rest.next())?;
                 match rest.next() {
-                    Some(CommandToken::Keyword(as_)) if as_.as_ref(buf) == b"as" => {}
-                    None => return Err(Diagnostic::CommandIncomplete(span)),
-                    Some(tk) => return Err(Diagnostic::CommandExpectedAs(tk.full_span())),
+                    Some(CommandToken::Keyword(as_)) if as_.as_ref(buf) == b"as" => Ok(s),
+                    None => Err(Diagnostic::CommandIncomplete(span)),
+                    Some(tk) => Err(Diagnostic::CommandExpectedAs(tk.full_span())),
                 }
-                Ok(s.into())
             };
-
+            let mut insert = |kind: MarkupKind, sp: Span, (sp2, val): (GlobalSpan, Token)| {
+                let map = match kind {
+                    MarkupKind::Html => &mut data.html_defs,
+                    MarkupKind::AltHtml => &mut data.alt_html_defs,
+                    MarkupKind::Latex => &mut data.latex_defs,
+                };
+                match map.entry(sp.as_ref(buf).into()) {
+                    Entry::Occupied(e) => {
+                        let (sp2, (id2, _), _) = *e.get();
+                        data.diagnostics
+                            .push((addr, Diagnostic::DuplicateMarkupDef(kind, (id2, sp2), sp)))
+                    }
+                    Entry::Vacant(e) => {
+                        e.insert((sp, sp2, val));
+                    }
+                }
+            };
             match cmd.as_ref(buf) {
-                b"latexdef" => {
-                    data.latex_defs.insert(as_(&mut rest)?, sum(rest)?);
-                }
-                b"htmldef" => {
-                    data.html_defs.insert(as_(&mut rest)?, sum(rest)?);
-                }
-                b"althtmldef" => {
-                    data.alt_html_defs.insert(as_(&mut rest)?, sum(rest)?);
-                }
+                b"latexdef" => insert(MarkupKind::Latex, as_(&mut rest)?, sum(rest)?),
+                b"htmldef" => insert(MarkupKind::Html, as_(&mut rest)?, sum(rest)?),
+                b"althtmldef" => insert(MarkupKind::AltHtml, as_(&mut rest)?, sum(rest)?),
                 b"htmlvarcolor" => data.html_var_color.push(sum(rest)?),
                 b"htmltitle" => data.html_title = Some(sum(rest)?),
                 b"htmlhome" => data.html_home = Some(sum(rest)?),
@@ -1070,8 +1084,8 @@ impl SegmentSet {
         let mut data = TypesettingData::default();
         for seg in self.segments(..) {
             for &(ix, (span, ref command)) in &seg.t_commands {
-                if let Err(diag) = parse_one(&mut data, &seg.buffer, span, command) {
-                    let address = StatementAddress::new(seg.id, ix);
+                let address = StatementAddress::new(seg.id, ix);
+                if let Err(diag) = parse_one(&mut data, &seg.buffer, address, span, command) {
                     data.diagnostics.push((address, diag))
                 }
             }

--- a/src/scopeck.rs
+++ b/src/scopeck.rs
@@ -41,7 +41,6 @@ use crate::util::{fast_extend, HashMap, HashSet};
 use crate::{parser, Label};
 use crate::{Database, StatementType};
 use crate::{Formula, StatementRef};
-use std::cmp::Ordering;
 use std::collections::VecDeque;
 use std::ops::Range;
 use std::sync::Arc;
@@ -301,7 +300,7 @@ fn check_math_symbol(
 ) -> Option<(SymbolType, Atom)> {
     // active global definition?
     if let Some(sdef) = state.gnames.lookup_symbol(&t_ref) {
-        if state.order.cmp(&sdef.address, &t_ref.address) == Ordering::Less {
+        if state.order.lt(&sdef.address, &t_ref.address) {
             return Some((sdef.stype, sdef.atom));
         }
     }
@@ -333,7 +332,7 @@ fn lookup_float<'a>(
 ) -> Option<LocalFloatInfo> {
     // active global definition?
     if let Some(fdef) = state.gnames.lookup_float(&t_ref) {
-        if state.order.cmp(&fdef.address, &s_ref.address()) == Ordering::Less {
+        if state.order.lt(&fdef.address, &s_ref.address()) {
             return Some(LocalFloatInfo {
                 valid: fdef.address.unbounded_range(),
                 typecode: fdef.typecode_atom,
@@ -845,7 +844,7 @@ fn scope_check_variable(state: &mut ScopeState<'_>, sref: StatementRef<'_>) {
             // nested $v, may conflict with an outer scope $v, top level $v/$c,
             // or a _later_ $c
             if let Some(cdef) = state.gnames.lookup_symbol(&tref) {
-                if state.order.cmp(&cdef.address, &tref.address) == Ordering::Less {
+                if state.order.lt(&cdef.address, &tref.address) {
                     push_diagnostic(
                         state,
                         sref.index(),

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -10,7 +10,8 @@ use crate::{
     diag::Diagnostic,
     statement::{
         Command, FloatDef, GlobalDv, HeadingDef, LabelDef, LocalVarDef, SegmentId, Span, Statement,
-        StatementAddress, StatementIndex, StatementIter, SymbolDef, TokenAddress,
+        StatementAddress, StatementIndex, StatementIter, SymbolDef, TokenAddress, DUMMY_STATEMENT,
+        NO_STATEMENT,
     },
     StatementRef,
 };
@@ -239,6 +240,21 @@ impl<'a> SegmentRef<'a> {
         StatementRef {
             segment: self,
             statement: &self.segment.statements[index as usize],
+            index,
+        }
+    }
+
+    /// Fetch a single statement from this segment by its local index,
+    /// or return a dummy statement when the index is `NO_STATEMENT`.
+    #[must_use]
+    pub(crate) fn statement_or_dummy(self, index: StatementIndex) -> StatementRef<'a> {
+        StatementRef {
+            segment: self,
+            statement: if index == NO_STATEMENT {
+                &DUMMY_STATEMENT
+            } else {
+                &self.segment.statements[index as usize]
+            },
             index,
         }
     }

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -131,6 +131,16 @@ pub(crate) trait Comparer<T> {
     /// Compares two objects, like `Ord::cmp`, but with additional state data
     /// from the comparer that can be used for the ordering.
     fn cmp(&self, left: &T, right: &T) -> Ordering;
+
+    #[inline]
+    fn lt(&self, left: &T, right: &T) -> bool {
+        self.cmp(left, right) == Ordering::Less
+    }
+
+    #[inline]
+    fn le(&self, left: &T, right: &T) -> bool {
+        self.cmp(left, right) != Ordering::Greater
+    }
 }
 
 impl Comparer<SegmentId> for SegmentOrder {

--- a/src/segment_set.rs
+++ b/src/segment_set.rs
@@ -209,6 +209,12 @@ impl SegmentSet {
         self.segment(addr.segment_id).statement(addr.index)
     }
 
+    /// Fetches a handle to a statement given a global address,
+    /// or return a dummy statement when the index is `NO_STATEMENT`.
+    pub(crate) fn statement_or_dummy(&self, addr: StatementAddress) -> StatementRef<'_> {
+        self.segment(addr.segment_id).statement_or_dummy(addr.index)
+    }
+
     /// Reports any parse errors associated with loaded segments.
     pub(crate) fn parse_diagnostics(&self) -> Vec<(StatementAddress, Diagnostic)> {
         let mut out = Vec::new();

--- a/src/segment_set.rs
+++ b/src/segment_set.rs
@@ -93,7 +93,7 @@ impl PartialEq for LongBuf {
 ///
 /// _This is likely to change when line number calculation is added._
 #[derive(Debug)]
-pub(crate) struct SourceInfo {
+pub struct SourceInfo {
     /// Name of the source file as loaded.
     pub(crate) name: String,
     /// Reference to the full unsliced source buffer.
@@ -101,6 +101,18 @@ pub(crate) struct SourceInfo {
     /// Span of the parser input within the file; all spans reported by the
     /// parser are relative to this.
     pub(crate) span: Span,
+}
+
+impl SourceInfo {
+    /// Build a new `SourceInfo` from a text buffer.
+    #[must_use]
+    pub fn new(name: String, text: Arc<Vec<u8>>) -> Self {
+        Self {
+            span: Span::new(0, text.len()),
+            name,
+            text,
+        }
+    }
 }
 
 /// The result of parsing one or more segments from a single slice of a source

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -601,19 +601,13 @@ impl<'a> StatementRef<'a> {
         }
     }
 
-    /// The contents of a comment statement, excluding the `$(` and `$)` delimiters,
-    /// and trimming an extra space from the trailing delimiter.
-    /// (We can't trim both sides without extra checks, because it would double count
-    /// the middle space in `$( $)`.)
+    /// The contents of a comment statement, excluding the `$(` and `$)` delimiters.
     #[must_use]
     pub const fn comment_contents(&self) -> Span {
-        Span::new2(self.statement.label.start + 2, self.span_full().end - 3)
+        Span::new2(self.statement.label.start + 2, self.span_full().end - 2)
     }
 
-    /// The contents of a comment statement, excluding the `$(` and `$)` delimiters,
-    /// and trimming an extra space from the trailing delimiter.
-    /// (We can't trim both sides without extra checks, because it would double count
-    /// the middle space in `$( $)`.)
+    /// Get an iterator over the markup items in this comment.
     #[must_use]
     pub fn comment_parser(&self) -> CommentParser<'a> {
         CommentParser::new(&self.segment.segment.buffer, self.comment_contents())

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -71,6 +71,7 @@ pub struct Span {
 
 impl Span {
     /// Coercion from array index pairs.
+    #[inline]
     #[must_use]
     pub const fn new(start: usize, end: usize) -> Span {
         Span {
@@ -80,6 +81,7 @@ impl Span {
     }
 
     /// Variant on `new` taking [`FilePos`] values.
+    #[inline]
     #[must_use]
     pub const fn new2(start: FilePos, end: FilePos) -> Span {
         Span { start, end }
@@ -89,18 +91,21 @@ impl Span {
     pub const NULL: Span = Span::new(0, 0);
 
     /// Checks for the null span, i.e. zero length at offset zero.
+    #[inline]
     #[must_use]
     pub const fn is_null(self) -> bool {
         self.end == 0
     }
 
     /// Get the length of the span.
+    #[inline]
     #[must_use]
     pub const fn len(self) -> usize {
         self.end as usize - self.start as usize
     }
 
     /// Is this an empty span?
+    #[inline]
     #[must_use]
     pub const fn is_empty(self) -> bool {
         self.start == self.end
@@ -108,6 +113,7 @@ impl Span {
 
     /// Given a position span, extract the corresponding characters from a
     /// buffer.
+    #[inline]
     #[must_use]
     pub fn as_ref(self, buf: &[u8]) -> &[u8] {
         &buf[self.start as usize..self.end as usize]
@@ -142,6 +148,7 @@ pub struct StatementAddress {
 
 impl StatementAddress {
     /// Constructs a statement address from its parts.
+    #[inline]
     #[must_use]
     pub const fn new(segment_id: SegmentId, index: StatementIndex) -> Self {
         StatementAddress { segment_id, index }
@@ -151,6 +158,7 @@ impl StatementAddress {
 impl StatementAddress {
     /// Convert a statement address into a statement range from here to the
     /// logical end of the database.
+    #[inline]
     #[must_use]
     pub const fn unbounded_range(self) -> GlobalRange {
         GlobalRange {
@@ -175,6 +183,7 @@ pub struct TokenAddress {
 
 impl TokenAddress {
     /// Constructs a token address from parts.
+    #[inline]
     #[must_use]
     pub const fn new3(segment_id: SegmentId, index: StatementIndex, token: TokenIndex) -> Self {
         TokenAddress {
@@ -380,18 +389,21 @@ impl Default for StatementType {
 
 impl StatementType {
     /// Returns true if this statement is an `Axiom` (`$a`) or `Provable` (`$p`) statement.
+    #[inline]
     #[must_use]
     pub const fn is_assertion(self) -> bool {
         matches!(self, Axiom | Provable)
     }
 
     /// Returns true if this statement has a label before the keyword: `$a $p $e $f`.
+    #[inline]
     #[must_use]
     pub const fn takes_label(self) -> bool {
         matches!(self, Axiom | Provable | Essential | Floating)
     }
 
     /// Returns true if this statement is followed by math tokens: `$a $p $e $f $d $c $v`.
+    #[inline]
     #[must_use]
     pub const fn takes_math(self) -> bool {
         matches!(
@@ -457,30 +469,35 @@ pub struct StatementRef<'a> {
 
 impl<'a> StatementRef<'a> {
     /// Fetch the segment-local index of this statement.
+    #[inline]
     #[must_use]
     pub const fn index(self) -> StatementIndex {
         self.index
     }
 
     /// Back up from a statement reference to a segment reference.
+    #[inline]
     #[must_use]
     pub const fn segment(self) -> SegmentRef<'a> {
         self.segment
     }
 
     /// Gets the type of this statement.  May be a pseudo-type.
+    #[inline]
     #[must_use]
     pub const fn statement_type(self) -> StatementType {
         self.statement.stype
     }
 
     /// Returns true if this statement is an `Axiom` (`$a`) or `Provable` (`$p`) statement.
+    #[inline]
     #[must_use]
     pub const fn is_assertion(self) -> bool {
         self.statement.stype.is_assertion()
     }
 
     /// Obtain a globally-meaningful address for this statement.
+    #[inline]
     #[must_use]
     pub const fn address(self) -> StatementAddress {
         StatementAddress {
@@ -494,6 +511,7 @@ impl<'a> StatementRef<'a> {
     ///
     /// This is the end range of a hypothesis or variable defined in this
     /// statement.
+    #[inline]
     #[must_use]
     pub const fn scope_range(self) -> GlobalRange {
         GlobalRange {
@@ -503,12 +521,14 @@ impl<'a> StatementRef<'a> {
     }
 
     /// True if there is a `${ $}` group wrapping this statement.
+    #[inline]
     #[must_use]
     pub const fn in_group(self) -> bool {
         self.statement.group_end != NO_STATEMENT
     }
 
     /// Obtain the span corresponding to the statment label.
+    #[inline]
     #[must_use]
     pub const fn label_span(&self) -> Span {
         self.statement.label
@@ -518,6 +538,7 @@ impl<'a> StatementRef<'a> {
     ///
     /// This will be non-null iff the type requires a label; missing labels for
     /// types which use them cause an immediate rewrite to `Invalid`.
+    #[inline]
     #[must_use]
     pub fn label(&self) -> &'a [u8] {
         self.label_span().as_ref(&self.segment.segment.buffer)
@@ -540,6 +561,7 @@ impl<'a> StatementRef<'a> {
     /// Does not include trailing white space or surrounding comments; will
     /// include leading white space, so a concatenation of spans for all
     /// statements will reconstruct the segment source.
+    #[inline]
     #[must_use]
     pub const fn span_full(&self) -> Span {
         self.statement.span
@@ -548,18 +570,21 @@ impl<'a> StatementRef<'a> {
     /// The textual span of this statement within the segment's buffer.
     ///
     /// Does not include surrounding white space or comments, unlike `span_full()`.
+    #[inline]
     #[must_use]
     pub const fn span(&self) -> Span {
         Span::new2(self.statement.label.start, self.span_full().end)
     }
 
     /// Count of symbols in this statement's math string.
+    #[inline]
     #[must_use]
     pub const fn math_len(&self) -> TokenIndex {
         (self.statement.proof_start - self.statement.math_start) as TokenIndex
     }
 
     /// Count of tokens in this statement's proof string.
+    #[inline]
     #[must_use]
     pub const fn proof_len(&self) -> TokenIndex {
         (self.statement.proof_end - self.statement.proof_start) as TokenIndex
@@ -567,6 +592,7 @@ impl<'a> StatementRef<'a> {
 
     /// Given an index into this statement's math string, find a textual span
     /// into the segment buffer.
+    #[inline]
     #[must_use]
     pub fn math_span(&self, ix: TokenIndex) -> Span {
         self.segment.span_pool[self.statement.math_start + ix as usize]
@@ -574,12 +600,14 @@ impl<'a> StatementRef<'a> {
 
     /// Given an index into this statement's proof string, find a textual span
     /// into the segment buffer.
+    #[inline]
     #[must_use]
     pub fn proof_span(&self, ix: TokenIndex) -> Span {
         self.segment.span_pool[self.statement.proof_start + ix as usize]
     }
 
     /// Get the list of spans of tokens in the proof.
+    #[inline]
     #[must_use]
     pub fn proof_spans(&self) -> &'a [Span] {
         &self.segment.segment.span_pool[self.statement.proof_start..self.statement.proof_end]
@@ -613,6 +641,7 @@ impl<'a> StatementRef<'a> {
     }
 
     /// Obtains textual proof data by token index.
+    #[inline]
     #[must_use]
     pub fn proof_slice_at(&self, ix: TokenIndex) -> TokenPtr<'a> {
         self.proof_span(ix).as_ref(&self.segment.segment.buffer)

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -35,7 +35,6 @@ use crate::segment_set::SegmentSet;
 use crate::statement::{SegmentId, Span, StatementAddress, TokenPtr, NO_STATEMENT};
 use crate::util::{fast_clear, fast_extend, HashMap};
 use crate::{parser, Database, StatementRef, StatementType};
-use std::cmp::Ordering;
 use std::mem;
 use std::ops::Range;
 use std::sync::Arc;
@@ -310,7 +309,7 @@ fn prepare_step<'a, P: ProofBuilder>(
     let valid = frame.valid;
     let pos = state.cur_frame.valid.start;
     try_assert!(
-        state.order.cmp(&pos, &valid.start) == Ordering::Greater,
+        state.order.lt(&valid.start, &pos),
         Diagnostic::StepUsedBeforeDefinition(label.into())
     );
 

--- a/src/verify_markup.rs
+++ b/src/verify_markup.rs
@@ -1,0 +1,354 @@
+use std::ops::Range;
+
+use regex::bytes::Regex;
+
+use crate::{
+    comment_parser::{Date, Parenthetical},
+    diag::{Diagnostic, MarkupKind},
+    scopeck::Hyp,
+    segment::SegmentRef,
+    statement::{StatementAddress, NO_STATEMENT},
+    Database, Span, StatementRef, StatementType,
+};
+
+#[derive(Copy, Clone, Debug)]
+pub struct VerifyMarkup {
+    pub check_dates: bool,
+    pub check_external_files: bool,
+    pub check_underscores: bool,
+    pub check_mathbox_ref: bool,
+}
+
+impl Default for VerifyMarkup {
+    fn default() -> Self {
+        Self {
+            check_dates: false,
+            check_external_files: false,
+            check_underscores: true,
+            check_mathbox_ref: true,
+        }
+    }
+}
+
+impl VerifyMarkup {
+    /// Check dates for consistency with the current date (default: false)
+    pub fn check_dates(&mut self, check: bool) -> &mut Self {
+        self.check_dates = check;
+        self
+    }
+
+    /// Check that external files exist (default: false)
+    pub fn check_external_files(&mut self, check: bool) -> &mut Self {
+        self.check_external_files = check;
+        self
+    }
+
+    /// Check labels for underscores (default: true)
+    pub fn check_underscores(&mut self, check: bool) -> &mut Self {
+        self.check_underscores = check;
+        self
+    }
+
+    /// Check for mathbox cross-references (default: true)
+    pub fn check_mathbox_ref(&mut self, check: bool) -> &mut Self {
+        self.check_mathbox_ref = check;
+        self
+    }
+
+    /// Run the verify markup pass on the given database.
+    pub fn run(self, db: &Database) -> Vec<(StatementAddress, Diagnostic)> {
+        db.verify_markup(self)
+    }
+}
+
+lazy_static::lazy_static! {
+    static ref WINDOWS_RESERVED_NAMES: Regex =
+        Regex::new("(?i)^(?:CON|PRN|AUX|NUL|(?:COM|LPT)[1-9])$").unwrap();
+}
+
+impl Database {
+    /// Run the verify markup pass on the database.
+    /// Requires: [`Database::scope_pass`], [`Database::typesetting_pass`]
+    #[allow(clippy::cognitive_complexity)]
+    #[must_use]
+    pub fn verify_markup(&self, opts: VerifyMarkup) -> Vec<(StatementAddress, Diagnostic)> {
+        let mut diags = vec![];
+        let tdata = &**self.typesetting_result();
+
+        for stmt in self.statements() {
+            if opts.check_underscores && stmt.label().contains(&b'_') {
+                diags.push((
+                    stmt.address(),
+                    Diagnostic::LabelContainsUnderscore(stmt.label_span()),
+                ))
+            }
+            if stmt.label().get(..2) == Some(b"mm") {
+                diags.push((
+                    stmt.address(),
+                    Diagnostic::MMReservedLabel(stmt.label_span()),
+                ))
+            }
+            if WINDOWS_RESERVED_NAMES.is_match(stmt.label()) {
+                diags.push((
+                    stmt.address(),
+                    Diagnostic::WindowsReservedLabel(stmt.label_span()),
+                ))
+            }
+            match stmt.statement_type() {
+                StatementType::Axiom => {
+                    if *stmt.math_at(0) == *b"|-"
+                        && !matches!(stmt.label().get(..3), Some(b"ax-" | b"df-"))
+                    {
+                        diags.push((
+                            stmt.address(),
+                            Diagnostic::UnconventionalAxiomLabel(stmt.label_span()),
+                        ))
+                    }
+                    if stmt.label().get(..3) == Some(b"ax-") {
+                        let mut label = Vec::from(*b"ax");
+                        label.extend_from_slice(&stmt.label()[3..]);
+                        if let Some(stmt2) = self.statement(&label) {
+                            if !eq_statement(self, stmt, stmt2) {
+                                diags.push((
+                                    stmt.address(),
+                                    Diagnostic::InvalidAxiomRestatement(
+                                        stmt.label_span(),
+                                        stmt2.label_span(),
+                                    ),
+                                ))
+                            }
+                        }
+                    }
+                }
+                StatementType::Constant | StatementType::Variable => {
+                    let buf = &stmt.segment.segment.buffer;
+                    for sp in (0..stmt.math_len()).map(|i| stmt.math_span(i)) {
+                        let tk = sp.as_ref(buf);
+                        if tk.contains(&b'@') {
+                            diags.push((stmt.address(), Diagnostic::ReservedAtToken(sp)))
+                        }
+                        if tk.contains(&b'?') {
+                            diags.push((stmt.address(), Diagnostic::ReservedQToken(sp)))
+                        }
+                        let html = !tdata.html_defs.contains_key(tk);
+                        let alt_html = !tdata.alt_html_defs.contains_key(tk);
+                        let latex = !tdata.latex_defs.contains_key(tk);
+                        if html || alt_html || latex {
+                            diags.push((
+                                stmt.address(),
+                                Diagnostic::MissingMarkupDef([html, alt_html, latex], sp),
+                            ))
+                        }
+                    }
+                }
+                _ => {}
+            }
+            if stmt.is_assertion() {
+                let buf = &stmt.segment.segment.buffer;
+                let mut contributor = None;
+                let mut laters = vec![];
+                let mut proof_mod = None;
+                let mut new_usage_discouraged = false;
+                let mut prev_date = None;
+                if let Some(comment) = stmt.associated_comment() {
+                    for (sp, paren) in comment.parentheticals() {
+                        let mut check_paren = |author: Span, date_sp: Span| {
+                            if author.as_ref(buf) == b"?who?" {
+                                diags.push((stmt.address(), Diagnostic::DefaultAuthor(author)))
+                            }
+
+                            if let Ok(date) = Date::try_from(date_sp.as_ref(buf)) {
+                                if let Some((prev_sp, prev)) = prev_date.replace((date_sp, date)) {
+                                    if prev > date {
+                                        diags.push((
+                                            stmt.address(),
+                                            Diagnostic::DateOrderError(prev_sp, date_sp),
+                                        ))
+                                    }
+                                }
+                            } else {
+                                diags.push((stmt.address(), Diagnostic::DateParseError(date_sp)))
+                            }
+                        };
+                        match paren {
+                            Parenthetical::ContributedBy { author, date } => {
+                                check_paren(author, date);
+                                if let Some(sp1) = contributor.replace(sp) {
+                                    diags.push((
+                                        stmt.address(),
+                                        Diagnostic::DuplicateContributor(sp1, sp),
+                                    ))
+                                }
+                            }
+                            Parenthetical::RevisedBy { author, date }
+                            | Parenthetical::ProofShortenedBy { author, date } => {
+                                check_paren(author, date);
+                                laters.push(sp)
+                            }
+                            Parenthetical::ProofModificationDiscouraged => proof_mod = Some(sp),
+                            Parenthetical::NewUsageDiscouraged => new_usage_discouraged = true,
+                        }
+                    }
+                }
+
+                if let Some(first) = contributor {
+                    for later in laters {
+                        if first.start > later.start {
+                            diags.push((stmt.address(), Diagnostic::ParenOrderError(first, later)))
+                        }
+                    }
+                } else if stmt.statement_type() != StatementType::Axiom
+                    || matches!(stmt.label().get(..3), Some(b"ax-" | b"df-"))
+                {
+                    diags.push((stmt.address(), Diagnostic::MissingContributor))
+                }
+
+                if stmt.statement_type() == StatementType::Axiom {
+                    if let Some(proof_mod) = proof_mod {
+                        diags.push((stmt.address(), Diagnostic::ProofModOnAxiom(proof_mod)))
+                    }
+                }
+
+                if (stmt.label().ends_with(b"OLD") || stmt.label().ends_with(b"ALT"))
+                    && (!new_usage_discouraged
+                        || (stmt.statement_type() != StatementType::Axiom && proof_mod.is_none()))
+                {
+                    diags.push((stmt.address(), Diagnostic::OldAltNotDiscouraged))
+                }
+            }
+        }
+
+        for seg in self.parse_result().segments(..) {
+            #[inline]
+            fn eol_check(
+                diags: &mut Vec<(StatementAddress, Diagnostic)>,
+                seg: &SegmentRef<'_>,
+                line_start: usize,
+                i: usize,
+            ) {
+                const MAX_LINE_LENGTH: usize = 79;
+                if i - line_start > MAX_LINE_LENGTH {
+                    diags.push((
+                        StatementAddress::new(seg.id, NO_STATEMENT),
+                        Diagnostic::LineLengthExceeded(Span::new(line_start + MAX_LINE_LENGTH, i)),
+                    ))
+                }
+                if i.checked_sub(1).and_then(|j| seg.buffer.get(j)) == Some(&b' ') {
+                    let start = seg.buffer[..i]
+                        .iter()
+                        .rposition(|&c| c != b' ')
+                        .map_or(0, |j| j + 1);
+                    diags.push((
+                        StatementAddress::new(seg.id, NO_STATEMENT),
+                        Diagnostic::TrailingWhitespace(Span::new(start, i)),
+                    ))
+                }
+            }
+            let mut line_start = 0;
+            let mut iter = seg.buffer.iter().enumerate();
+            while let Some((i, &c)) = iter.next() {
+                match c {
+                    b'\n' => {
+                        eol_check(&mut diags, &seg, line_start, i);
+                        line_start = i + 1;
+                    }
+                    b'\t' => {
+                        let count = seg.buffer[i..].iter().take_while(|&&c| c == b'\t').count();
+                        for _ in 1..count {
+                            iter.next();
+                        }
+                        diags.push((
+                            StatementAddress::new(seg.id, NO_STATEMENT),
+                            Diagnostic::TabUsed(Span::new(i, i + count)),
+                        ))
+                    }
+                    _ => {}
+                }
+            }
+            eol_check(&mut diags, &seg, line_start, seg.buffer.len());
+        }
+
+        for (kind, map) in [
+            (MarkupKind::Html, &tdata.html_defs),
+            (MarkupKind::AltHtml, &tdata.alt_html_defs),
+            (MarkupKind::Latex, &tdata.latex_defs),
+        ] {
+            for (tk, (sp, (seg_id, _), _)) in map {
+                if self.name_result().lookup_symbol(tk).is_none() {
+                    diags.push((
+                        StatementAddress::new(*seg_id, NO_STATEMENT),
+                        Diagnostic::UndefinedMarkupDef(kind, *sp),
+                    ))
+                }
+            }
+        }
+
+        if let Some((sp, tk)) = &tdata.ext_html_label {
+            if self.name_result().lookup_label(tk).is_none() {
+                diags.push((
+                    StatementAddress::new(sp.0, NO_STATEMENT),
+                    Diagnostic::UnknownLabel(sp.1),
+                ))
+            }
+        }
+
+        // omitted: check that files in IMG SRC="..." of html_defs exist
+        // omitted: check that html_home has HREF="..." and IMG SRC="..."
+        // omitted: check that ext_html_home has HREF="..." and IMG SRC="..."
+        // omitted: top date check
+
+        // todo: section header comments
+        // todo: bibliographic references
+        // todo: mathbox independence
+
+        diags
+    }
+}
+
+// TODO: use Iterator::eq_by, rust#64295
+fn eq_by<T, U>(
+    iter1: impl IntoIterator<Item = T>,
+    iter2: impl IntoIterator<Item = U>,
+    f: impl Fn(T, U) -> bool,
+) -> bool {
+    let mut iter1 = iter1.into_iter();
+    let mut iter2 = iter2.into_iter();
+    loop {
+        match (iter1.next(), iter2.next()) {
+            (None, None) => return true,
+            (Some(a), Some(b)) => {
+                if !f(a, b) {
+                    return false;
+                }
+            }
+            _ => return false,
+        }
+    }
+}
+
+fn eq_statement(db: &Database, stmt1: StatementRef<'_>, stmt2: StatementRef<'_>) -> bool {
+    let it1 = stmt1.math_iter().map(|tk| tk.slice);
+    let it2 = stmt2.math_iter().map(|tk| tk.slice);
+    it1.eq(it2) && {
+        let fr1 = db.scope_result().get(stmt1.label()).unwrap();
+        let fr2 = db.scope_result().get(stmt2.label()).unwrap();
+        eq_by(
+            fr1.mandatory_hyps(),
+            fr2.mandatory_hyps(),
+            |h1, h2| match (h1, h2) {
+                (Hyp::Essential(_, e1), Hyp::Essential(_, e2)) => {
+                    let eq_span = |s1: &Range<usize>, s2: &Range<usize>| {
+                        fr1.const_pool[s1.clone()] == fr2.const_pool[s2.clone()]
+                    };
+                    e1.typecode == e2.typecode
+                        && eq_by(&*e1.tail, &*e2.tail, |frag1, frag2| {
+                            eq_span(&frag1.prefix, &frag2.prefix) && frag1.var == frag2.var
+                        })
+                        && eq_span(&e1.rump, &e2.rump)
+                }
+                (Hyp::Floating(_, i1, tc1), Hyp::Floating(_, i2, tc2)) => i1 == i2 && tc1 == tc2,
+                _ => false,
+            },
+        ) && fr1.mandatory_dv == fr2.mandatory_dv
+    }
+}

--- a/src/verify_markup.rs
+++ b/src/verify_markup.rs
@@ -64,7 +64,7 @@ impl VerifyMarkup {
 
 lazy_static::lazy_static! {
     static ref WINDOWS_RESERVED_NAMES: Regex =
-        Regex::new("(?i)^(?:CON|PRN|AUX|NUL|(?:COM|LPT)[1-9])$").unwrap();
+        Regex::new("(?i-u)^(?:CON|PRN|AUX|NUL|(?:COM|LPT)[1-9])$").unwrap();
 }
 
 impl Database {
@@ -395,7 +395,7 @@ fn verify_markup_comment(db: &Database, buf: &[u8], span: Span, mut diag: impl F
         match item {
             CommentItem::Text(sp) => {
                 lazy_static::lazy_static! {
-                    static ref HTML: Regex = Regex::new("(?i)</?HTML>").unwrap();
+                    static ref HTML: Regex = Regex::new("(?i-u)</?HTML>").unwrap();
                 }
                 check_uninterpreted_escapes(buf, sp, &mut diag);
                 let text = sp.as_ref(buf);


### PR DESCRIPTION
This replicates the functionality of metamath.exe's `VERIFY MARKUP` command. New checks:

1. Labels should not contain `_`
2. Labels should not start with `mm`
3. Labels should not match reserved windows filenames `CON, PRN, AUX` etc
4. If there is an axiom `ax-foo` with a corresponding `axfoo` axiom/theorem then they should match
5. Axioms that prove `|- ...` should have a name `ax-*` or `df-*`
6. Tokens should not use the `@` and `?` characters
7. Every token should have a `htmldef` command
8. Use of the author `?who?` is forbidden
9. Dates should parse
10. Parentheticals should come in chronological order
11. Axioms and theorems (except for syntax axioms) should have a `Contributed by` comment
12. There should not be two `Contributed by` comments
13. The `Contributed by` comment should be the first one in the list
14. Proof modification is discouraged` is not allowed on axioms
15. `*OLD` and `*ALT` theorems should be marked as `(Proof modification is discouraged.)` and `(New usage is discouraged.)`
16. Lines should have at most 79 characters (TODO: make an exception for lines with URLs)
17. There should be no trailing whitespace
18. Tabs should not appear anywhere
19. There should not be two `htmldef` (and `althtmldef`, `latexdef`) commands for the same token
20. Tokens appearing in `htmldef` should be declared
21. The `exthtmllabel` command should reference an existing label
22. Header comments (defined as starting with `$( <whitespace> #*#*...`) should parse as header comments (decorator, newline, one line of text, newline, decorator, markup text)
23. The `~` and `` ` `` characters, when used as delimiters in markup, should have whitespace around them
24. Characters `[`, `~` and `` ` `` must be doubled if they could not be interpreted as special in markup
25. `<HTML>` and `</HTML>` must appear in all caps, not nested, and in balanced pairs
26. Tokens inside `` ` `` math strings in markup must exist in a `$c`/`$v` statement
27. Math strings must be closed before the end of the comment
28. `<HTML>` must be closed before the end of the comment
29. Label references via `~` must not be empty (because the `~` was at the end of the comment or was aborted by a higher priority markup)
30. Bibliography tags must not contain `~` or `` ` ``
31. Bibliography tags must reference an `<a name="...">` tag in the bibliography file, if provided
32. Mathbox headers (section headers after the `mathbox` label) must have the form `Mathbox for X`
33. Mathboxes should not refer to theorems from other mathboxes

Interestingly, (10) is not implemented in exactly the same way in metamath.exe, and running this on set.mm has unearthed two issues:

* [ssfin4](http://us.metamath.org/mpeuni/ssfin4.html) has two revised-by attributions out of order
* [cshwidxm1](http://us.metamath.org/mpeuni/cshwidxm1.html) has a revision date prior to its contributed-by date