### PR TITLE
String parsing : fix issue with multiple whitespaces in a row

### DIFF
--- a/src/grammar_tests.rs
+++ b/src/grammar_tests.rs
@@ -151,6 +151,10 @@ fn test_parse_string() {
     let grammar = db.grammar_pass().clone();
     let formula = grammar.parse_string("|- A = ( B + A )", &names).unwrap();
     assert_eq!(formula.as_ref(&db).as_sexpr(), "(weq cA (cadd cB cA))");
+    let formula = grammar
+        .parse_string("|- A\n   = ( B + A )\n\n", &names)
+        .unwrap();
+    assert_eq!(formula.as_ref(&db).as_sexpr(), "(weq cA (cadd cB cA))");
 }
 
 // This grammar exposes issue #32 in the statement parser


### PR DESCRIPTION
Edit this fixes the case when tokens in a math string are not separated by single, but multiple whitespaces.
With these changes, `metamath-knife` does not attempt to resolve the "empty" tokens in between.