### PR TITLE
Implement `Comparer` trait for the Database

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,7 @@ pub use formula::Formula;
 pub use formula::FormulaRef;
 pub use formula::Label;
 pub use formula::Symbol;
+pub use segment::Comparer;
 pub use segment_set::SourceInfo;
 pub use statement::as_str;
 pub use statement::Span;

--- a/src/outline.rs
+++ b/src/outline.rs
@@ -347,11 +347,8 @@ impl<'a> OutlineNodeRef<'a> {
                 let end = if let Some(next_stmt) = self.next_after_children() {
                     next_stmt.get_statement().span().start - 1
                 } else {
-                    database
-                        .parse_result()
-                        .source_info(stmt.segment.id)
-                        .span
-                        .end
+                    let segment_span = database.parse_result().source_info(stmt.segment.id).span;
+                    segment_span.end - segment_span.start
                 };
                 Span { start, end }
             }

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -13,7 +13,7 @@ use crate::{
         StatementAddress, StatementIndex, StatementIter, SymbolDef, TokenAddress, DUMMY_STATEMENT,
         NO_STATEMENT,
     },
-    StatementRef,
+    Database, StatementRef,
 };
 
 /// Data structure which tracks the logical order of segment IDs, since they are
@@ -127,16 +127,18 @@ impl<'a> DoubleEndedIterator for SegmentIter<'a> {
 }
 
 /// A trait for objects which can be used to order other datatypes.
-pub(crate) trait Comparer<T> {
+pub trait Comparer<T> {
     /// Compares two objects, like `Ord::cmp`, but with additional state data
     /// from the comparer that can be used for the ordering.
     fn cmp(&self, left: &T, right: &T) -> Ordering;
 
+    /// Returns true if the `left` argument is (strictly) less than the `right` argument
     #[inline]
     fn lt(&self, left: &T, right: &T) -> bool {
         self.cmp(left, right) == Ordering::Less
     }
 
+    /// Returns true if the `left` argument is less or equal to the `right` argument
     #[inline]
     fn le(&self, left: &T, right: &T) -> bool {
         self.cmp(left, right) != Ordering::Greater
@@ -160,6 +162,24 @@ impl Comparer<TokenAddress> for SegmentOrder {
     fn cmp(&self, left: &TokenAddress, right: &TokenAddress) -> Ordering {
         self.cmp(&left.statement, &right.statement)
             .then_with(|| left.token_index.cmp(&right.token_index))
+    }
+}
+
+impl Comparer<SegmentId> for Database {
+    fn cmp(&self, left: &SegmentId, right: &SegmentId) -> Ordering {
+        self.parse_result().order.cmp(left, right)
+    }
+}
+
+impl Comparer<StatementAddress> for Database {
+    fn cmp(&self, left: &StatementAddress, right: &StatementAddress) -> Ordering {
+        self.parse_result().order.cmp(left, right)
+    }
+}
+
+impl Comparer<TokenAddress> for Database {
+    fn cmp(&self, left: &TokenAddress, right: &TokenAddress) -> Ordering {
+        self.parse_result().order.cmp(left, right)
     }
 }
 

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -153,9 +153,7 @@ impl StatementAddress {
     pub const fn new(segment_id: SegmentId, index: StatementIndex) -> Self {
         StatementAddress { segment_id, index }
     }
-}
 
-impl StatementAddress {
     /// Convert a statement address into a statement range from here to the
     /// logical end of the database.
     #[inline]


### PR DESCRIPTION
The `SegmentOrder` which allows to compare statement addresses and token addresses is private.
This implements the `Comparer` trait for the `Database`, so that comparing statement addresses is possible on the API.