### PR TITLE
New trait to support work variables

### DIFF
--- a/src/diag.rs
+++ b/src/diag.rs
@@ -1190,6 +1190,7 @@ impl Diagnostic {
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[allow(missing_docs)]
 pub enum StmtParseError {
+    NoWorkVariable,
     ParsedStatementTooShort(Span, Option<Token>),
     ParsedStatementNoTypeCode,
     ParsedStatementWrongTypeCode(Token),
@@ -1202,6 +1203,7 @@ impl StmtParseError {
     #[must_use]
     pub fn label<'a>(&self) -> Cow<'a, str> {
         match self {
+            StmtParseError::NoWorkVariable => "Work Variables are not implemented",
             StmtParseError::ParsedStatementTooShort(_, _) => "Parsed statement too short",
             StmtParseError::ParsedStatementWrongTypeCode(_) => {
                 "Parsed statement has wrong typecode"
@@ -1226,6 +1228,12 @@ impl StmtParseError {
         }
         let severity = self.severity();
         let info = match self {
+            StmtParseError::NoWorkVariable => (
+                AnnotationType::Error,
+                "Callers must implement their own resolvers to have this functionality".into(),
+                stmt,
+                stmt.span(),
+            ),
             StmtParseError::ParsedStatementTooShort(span, ref opt_tok) => (
                 severity,
                 match opt_tok {

--- a/src/grammar_tests.rs
+++ b/src/grammar_tests.rs
@@ -116,7 +116,7 @@ fn test_parse_formula() {
             &mut fmla_vec.clone().into_iter(),
             &[wff, class],
             false,
-            &names,
+            &names as &Nameset,
         )
         .unwrap();
     // Accessing formula using paths to labels
@@ -162,10 +162,12 @@ fn test_parse_string() {
     let mut db = mkdb(GRAMMAR_DB);
     let names = db.name_pass().clone();
     let grammar = db.grammar_pass().clone();
-    let formula = grammar.parse_string("|- A = ( B + A )", &names).unwrap();
+    let formula = grammar
+        .parse_string("|- A = ( B + A )", &names as &Nameset)
+        .unwrap();
     assert_eq!(formula.as_ref(&db).as_sexpr(), "(weq cA (cadd cB cA))");
     let formula = grammar
-        .parse_string("|- A\n   = ( B + A )\n\n", &names)
+        .parse_string("|- A\n   = ( B + A )\n\n", &names as &Nameset)
         .unwrap();
     assert_eq!(formula.as_ref(&db).as_sexpr(), "(weq cA (cadd cB cA))");
 }
@@ -216,7 +218,7 @@ fn test_setvar_as_class() {
                 &mut vec![x_symbol].into_iter(),
                 &[class_symbol],
                 false,
-                &names,
+                &names as &Nameset,
             )
             .unwrap();
         assert_eq!(formula.as_ref(&db).as_sexpr(), "(cv vx)");

--- a/src/nameck.rs
+++ b/src/nameck.rs
@@ -328,6 +328,12 @@ impl Nameset {
             .get(name)
             .expect("please only use get_atom for local $v")
     }
+    
+    /// Returns the last known atom
+    #[must_use]
+    pub fn last_atom(&self) -> Atom {
+        Atom(self.atom_table.table.len() as u32)
+    }
 
     /// Map atoms back to names.
     ///


### PR DESCRIPTION
This introduces a trait `Resolver` meant to handle work variables outside of metamath-knife.

The new trait shall be able to resolve work variable names like e.g. `&W1` into a virtual symbol, as well as into the corresponding a virtual floating axiom, and vice-versa for printing back that symbol.

An implementation is provided in the form of `Nameset`, which does not resolve any additional work variables, but only regular symbols straight from the database.