### PR TITLE
add double-quote escape in $t/$j comments

### DIFF
--- a/src/comment_parser.rs
+++ b/src/comment_parser.rs
@@ -19,7 +19,7 @@ use std::fmt::Display;
 use lazy_static::lazy_static;
 use regex::bytes::{CaptureMatches, Match, Regex, RegexSet};
 
-use crate::Span;
+use crate::{statement::unescape, Span};
 
 /// A comment markup item, which represents either a piece of text from the input
 /// or some kind of metadata item like the start or end of an italicized group.
@@ -71,22 +71,6 @@ pub enum CommentItem {
     EndItalic(usize),
     /// A bibliographic label `[foo]`. No escapes are needed inside the tag body.
     BibTag(Span),
-}
-
-#[inline]
-fn unescape(mut buf: &[u8], out: &mut Vec<u8>, is_escape: impl FnOnce(u8) -> bool + Copy) {
-    while let Some(n) = buf.iter().position(|&c| is_escape(c)) {
-        out.extend_from_slice(&buf[..=n]);
-        if buf.get(n + 1) == Some(&buf[n]) {
-            buf = &buf[n + 2..];
-        } else {
-            // this will not normally happen, but in some cases unescaped escapes
-            // are left uninterpreted because they appear in invalid position,
-            // and in that case they should be left as is
-            buf = &buf[n + 1..];
-        }
-    }
-    out.extend_from_slice(buf);
 }
 
 /// Returns true if this is a character that is escaped in [`CommentItem::Text`],

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -31,7 +31,7 @@
 //! `SegmentId` and `SegmentRef` cover the same use cases for segments, although
 //! it makes no sense to have a segment-local segment reference.
 
-use std::ops::Deref;
+use std::{borrow::Cow, ops::Deref};
 
 use crate::{
     comment_parser::{CommentParser, Discouragements, ParentheticalIter},
@@ -301,6 +301,26 @@ pub struct HeadingDef {
     pub level: HeadingLevel,
 }
 
+#[inline]
+pub(crate) fn unescape(
+    mut buf: &[u8],
+    out: &mut Vec<u8>,
+    is_escape: impl FnOnce(u8) -> bool + Copy,
+) {
+    while let Some(n) = buf.iter().position(|&c| is_escape(c)) {
+        out.extend_from_slice(&buf[..=n]);
+        if buf.get(n + 1) == Some(&buf[n]) {
+            buf = &buf[n + 2..];
+        } else {
+            // this will not normally happen, but in some cases unescaped escapes
+            // are left uninterpreted because they appear in invalid position,
+            // and in that case they should be left as is
+            buf = &buf[n + 1..];
+        }
+    }
+    out.extend_from_slice(buf);
+}
+
 /// An individual symbol in a command, either a string or other keyword.
 #[derive(Clone, Copy, Debug)]
 pub enum CommandToken {
@@ -313,9 +333,10 @@ pub enum CommandToken {
 impl CommandToken {
     /// Get the string corresponding to this token.
     #[must_use]
-    pub fn value(self, buf: &[u8]) -> TokenPtr<'_> {
+    pub fn value(self, buf: &[u8]) -> Cow<'_, [u8]> {
         match self {
-            Self::Keyword(s) | Self::String(s) => s.as_ref(buf),
+            Self::Keyword(s) => Cow::Borrowed(s.as_ref(buf)),
+            Self::String(s) => Self::unescape_string(buf, s),
         }
     }
 
@@ -325,6 +346,26 @@ impl CommandToken {
         match self {
             Self::Keyword(s) => s,
             Self::String(s) => Span::new2(s.start - 1, s.end + 1),
+        }
+    }
+
+    /// Remove doubled quote escapes from a [`CommandToken::String`]`(span)`.
+    pub fn append_unescaped_string(buf: &[u8], span: Span, out: &mut Vec<u8>) {
+        let quote = buf[(span.start - 1) as usize];
+        unescape(span.as_ref(buf), out, |c| quote == c)
+    }
+
+    /// Remove doubled quote escapes from a [`CommandToken::String`]`(span)`.
+    #[must_use]
+    pub fn unescape_string(buf: &[u8], span: Span) -> Cow<'_, [u8]> {
+        let quote = buf[(span.start - 1) as usize];
+        let buf = span.as_ref(buf);
+        if buf.contains(&quote) {
+            let mut out = vec![];
+            unescape(span.as_ref(buf), &mut out, |c| quote == c);
+            out.into()
+        } else {
+            Cow::Borrowed(buf)
         }
     }
 }


### PR DESCRIPTION
This adds support for strings like `"ab""c"` in $t and $j comments which encode the string `ab"c`. 

Some additional care is required in user code, since now the body of a string is no longer the actual contents of the string but rather doubled characters have to be unescaped. We return a `Cow` now and check for the very common case of no escapes to avoid the copy most of the time. But if working directly with string spans, `CommandToken::unescape_string` should be used to get the value now.