### PR TITLE
expose ProofTreePrinter, make enable_exprs optional

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -810,7 +810,7 @@ impl Database {
     /// in the form of a `ProofTreeArray`
     #[must_use]
     pub fn get_proof_tree(&self, sref: StatementRef<'_>) -> Option<ProofTreeArray> {
-        ProofTreeArray::new(self, sref).ok()
+        ProofTreeArray::from_stmt(self, sref, true).ok()
     }
 
     /// Returns the syntax proof tree for a given formula,


### PR DESCRIPTION
This makes it possible to disable expr collection inside `ProofTreeArray`, which is not required when the goal is to build a compressed proof. It also exposes `ProofTreePrinter` (although possibly the API could use some work) so that it is possible to generate compressed proofs without going through MMP. Eventually it would be nice to have a proof editing interface like metamath.exe's `save proof`; I already have some use cases for that but probably won't be able to get to it soon.