### PR TITLE
Add tests with Ubuntu-latest

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-latest, macOS-latest]
+        os: [ubuntu-20.04, ubuntu-latest, windows-latest, macOS-latest]
         rust: [stable] # [stable, nightly]
     # needs: skip_dups
     # if: ${{ needs.skip_dups.outputs.should_skip != 'true' }}


### PR DESCRIPTION
I'm keeping ubuntu-20.04 to test it on an older release, but we should also test on the current LTS release (ubuntu-latest).

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>