### PR TITLE
Generate `discouraged` file

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -385,7 +385,7 @@ impl<T> Promise<T> {
 /// without affecting the other.
 #[derive(Clone, Debug)]
 pub struct Database {
-    options: Arc<DbOptions>,
+    pub(crate) options: Arc<DbOptions>,
     segments: Arc<SegmentSet>,
     /// We track the "current" and "previous" for all known passes, so that each
     /// pass can use its most recent results for optimized incremental
@@ -409,7 +409,7 @@ impl Default for Database {
     }
 }
 
-fn time<R, F: FnOnce() -> R>(opts: &DbOptions, name: &str, f: F) -> R {
+pub(crate) fn time<R, F: FnOnce() -> R>(opts: &DbOptions, name: &str, f: F) -> R {
     let now = Instant::now();
     let ret = f();
     if opts.timing {

--- a/src/discouraged.rs
+++ b/src/discouraged.rs
@@ -1,0 +1,96 @@
+//! Regeneration of the `discouraged` file.
+//!
+//! This module attempts to reproduce the same function of metamath-exe, see [function `showDiscouraged`](https://github.com/metamath/metamath-exe/blob/86c5c2c5118bb8a4274925a4eb550fc58c3ca705/src/mmcmds.c#L5408)
+use std::io::Write;
+use std::{collections::HashMap, fs::File};
+
+use crate::{
+    as_str, comment_parser::Discouragements, database::time, diag::Diagnostic,
+    proof::ProofTreeArray, Database,
+};
+use crate::{StatementRef, StatementType};
+use std::collections::{BTreeMap, BTreeSet};
+
+impl Database {
+    /// Regenerates the `discouraged` file in the current directory
+    pub fn regen_discouraged(&self) -> Result<(), Diagnostic> {
+        time(&self.options.clone(), "discouraged", || {
+            self.output_discouraged(&mut File::create("discouraged")?)
+        })
+    }
+
+    /// Regenerates a `discouraged` file into the provided output file
+    /// Requires: [`Database::scope_pass`], [`Database::typesetting_pass`]
+    pub fn output_discouraged(&self, out: &mut File) -> Result<(), Diagnostic> {
+        let mut usage_discouraged_map = HashMap::new();
+        let mut usage_discouraged_list = BTreeMap::new();
+        let mut modif_discouraged_list = BTreeMap::new();
+        for sref in self.statements().filter(|stmt| stmt.is_assertion()) {
+            let Discouragements {
+                modification_discouraged,
+                usage_discouraged,
+            } = sref.discouragements();
+            let label = as_str(sref.label());
+            if usage_discouraged {
+                usage_discouraged_list.insert(label, sref.address());
+                usage_discouraged_map.insert(sref.address(), BTreeSet::new());
+            }
+            if sref.statement_type() == StatementType::Provable {
+                let steps = match ProofTreeArray::from_stmt(self, sref, false) {
+                    Ok(proof) => {
+                        for step in proof.trees {
+                            if let Some(usage) = usage_discouraged_map.get_mut(&step.address) {
+                                usage.insert(label);
+                            };
+                        }
+                        step_count(sref)
+                    }
+                    _ => 0,
+                };
+                if modification_discouraged {
+                    modif_discouraged_list.insert(label, steps);
+                }
+            }
+        }
+        for (label, saddr) in &usage_discouraged_list {
+            if let Some(uses) = usage_discouraged_map.get(saddr) {
+                for used_by in uses {
+                    writeln!(out, "\"{label}\" is used by \"{used_by}\".")?;
+                }
+            }
+        }
+        for (label, saddr) in usage_discouraged_list {
+            let uses = usage_discouraged_map.get(&saddr).map_or(0, BTreeSet::len);
+            writeln!(
+                out,
+                "New usage of \"{label}\" is discouraged ({uses} uses)."
+            )?;
+        }
+        for (label, steps) in modif_discouraged_list {
+            writeln!(
+                out,
+                "Proof modification of \"{label}\" is discouraged ({steps} steps)."
+            )?;
+        }
+        Ok(())
+    }
+}
+
+/// Attempts to emulate counting proof steps from metamath-exe
+/// This appears to sometimes be off by 3 or 6 steps.
+fn step_count(stmt: StatementRef<'_>) -> usize {
+    if stmt.proof_len() > 0 && stmt.proof_slice_at(0) == b"(" {
+        // This is a compressed proof
+        let mut i = 0;
+        let mut step_count = 0;
+        while i < stmt.proof_len() {
+            let chunk = stmt.proof_slice_at(i);
+            step_count += chunk.iter().filter(|ch| (b'A'..=b'T').contains(ch)).count();
+            i += 1;
+        }
+        step_count
+    } else {
+        // This is an uncompressed proof
+        stmt.proof_len() as usize
+    }
+}

--- a/src/discouraged.rs
+++ b/src/discouraged.rs
@@ -1,19 +1,16 @@
 //! Regeneration of the `discouraged` file.
 //!
-//! This module attempts to reproduce the same function of metamath-exe, see [function `showDiscouraged`](https://github.com/metamath/metamath-exe/blob/86c5c2c5118bb8a4274925a4eb550fc58c3ca705/src/mmcmds.c#L5408)
-use std::io::Write;
-use std::{collections::HashMap, fs::File};
+//! This module attempts to reproduce the same function of metamath-exe, see
+//! [function `showDiscouraged`](https://github.com/metamath/metamath-exe/blob/86c5c2c5/src/mmcmds.c#L5408)
+use std::fs::File;
 
-use crate::{
-    as_str, comment_parser::Discouragements, database::time, diag::Diagnostic,
-    proof::ProofTreeArray, Database,
-};
-use crate::{StatementRef, StatementType};
+use crate::StatementType;
+use crate::{as_str, comment_parser::Discouragements, database::time, Database};
 use std::collections::{BTreeMap, BTreeSet};
 
 impl Database {
     /// Regenerates the `discouraged` file in the current directory
-    pub fn regen_discouraged(&self) -> Result<(), Diagnostic> {
+    pub fn regen_discouraged(&self) -> Result<(), std::io::Error> {
         time(&self.options.clone(), "discouraged", || {
             self.output_discouraged(&mut File::create("discouraged")?)
         })
@@ -21,76 +18,75 @@ impl Database {
 
     /// Regenerates a `discouraged` file into the provided output file
     /// Requires: [`Database::scope_pass`], [`Database::typesetting_pass`]
-    pub fn output_discouraged(&self, out: &mut File) -> Result<(), Diagnostic> {
-        let mut usage_discouraged_map = HashMap::new();
-        let mut usage_discouraged_list = BTreeMap::new();
-        let mut modif_discouraged_list = BTreeMap::new();
+    pub fn output_discouraged(&self, out: &mut impl std::io::Write) -> Result<(), std::io::Error> {
+        let mut usage_discouraged_map = BTreeMap::new();
+        let mut modif_discouraged_map = BTreeMap::new();
         for sref in self.statements().filter(|stmt| stmt.is_assertion()) {
             let Discouragements {
                 modification_discouraged,
                 usage_discouraged,
             } = sref.discouragements();
-            let label = as_str(sref.label());
+            let label = sref.label();
             if usage_discouraged {
-                usage_discouraged_list.insert(label, sref.address());
-                usage_discouraged_map.insert(sref.address(), BTreeSet::new());
+                usage_discouraged_map.insert(label, BTreeSet::new());
             }
             if sref.statement_type() == StatementType::Provable {
-                let steps = match ProofTreeArray::from_stmt(self, sref, false) {
-                    Ok(proof) => {
-                        for step in proof.trees {
-                            if let Some(usage) = usage_discouraged_map.get_mut(&step.address) {
-                                usage.insert(label);
-                            };
+                let mut steps;
+                if sref.proof_len() > 0 && sref.proof_slice_at(0) == b"(" {
+                    let mut i = 1;
+                    while i < sref.proof_len() {
+                        let tk = sref.proof_slice_at(i);
+                        i += 1;
+                        if tk == b")" {
+                            break;
                         }
-                        step_count(sref)
+                        if let Some(usage) = usage_discouraged_map.get_mut(tk) {
+                            usage.insert(label);
+                        }
                     }
-                    _ => 0,
-                };
+                    steps = 0;
+                    while i < sref.proof_len() {
+                        let chunk = sref.proof_slice_at(i);
+                        steps += chunk.iter().filter(|ch| (b'A'..=b'T').contains(ch)).count();
+                        i += 1;
+                    }
+                } else {
+                    let mut i = 0;
+                    while i < sref.proof_len() {
+                        let tk = sref.proof_slice_at(i);
+                        if let Some(usage) = usage_discouraged_map.get_mut(tk) {
+                            usage.insert(label);
+                        }
+                        i += 1;
+                    }
+                    steps = i as usize;
+                }
                 if modification_discouraged {
-                    modif_discouraged_list.insert(label, steps);
+                    modif_discouraged_map.insert(label, steps);
                 }
             }
         }
-        for (label, saddr) in &usage_discouraged_list {
-            if let Some(uses) = usage_discouraged_map.get(saddr) {
-                for used_by in uses {
-                    writeln!(out, "\"{label}\" is used by \"{used_by}\".")?;
-                }
+        for (label, uses) in &usage_discouraged_map {
+            let label = as_str(label);
+            for used_by in uses {
+                writeln!(out, "\"{label}\" is used by \"{}\".", as_str(used_by))?;
             }
         }
-        for (label, saddr) in usage_discouraged_list {
-            let uses = usage_discouraged_map.get(&saddr).map_or(0, BTreeSet::len);
+        for (label, uses) in usage_discouraged_map {
+            let label = as_str(label);
+            let uses = uses.len();
             writeln!(
                 out,
                 "New usage of \"{label}\" is discouraged ({uses} uses)."
             )?;
         }
-        for (label, steps) in modif_discouraged_list {
+        for (label, steps) in modif_discouraged_map {
+            let label = as_str(label);
             writeln!(
                 out,
                 "Proof modification of \"{label}\" is discouraged ({steps} steps)."
             )?;
         }
         Ok(())
-    }
-}
-
-/// Attempts to emulate counting proof steps from metamath-exe
-/// This appears to sometimes be off by 3 or 6 steps.
-fn step_count(stmt: StatementRef<'_>) -> usize {
-    if stmt.proof_len() > 0 && stmt.proof_slice_at(0) == b"(" {
-        // This is a compressed proof
-        let mut i = 0;
-        let mut step_count = 0;
-        while i < stmt.proof_len() {
-            let chunk = stmt.proof_slice_at(i);
-            step_count += chunk.iter().filter(|ch| (b'A'..=b'T').contains(ch)).count();
-            i += 1;
-        }
-        step_count
-    } else {
-        // This is an uncompressed proof
-        stmt.proof_len() as usize
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ mod util;
 pub mod comment_parser;
 pub mod database;
 pub mod diag;
+pub mod discouraged;
 pub mod export;
 pub mod formula;
 pub mod grammar;

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,7 +123,7 @@ fn main() {
 
         if matches.is_present("discouraged") {
             db.regen_discouraged()
-                .unwrap_or_else(|diag| diags.push((StatementAddress::default(), diag)));
+                .unwrap_or_else(|diag| diags.push((StatementAddress::default(), diag.into())));
         }
 
         let mut count = db

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use annotate_snippets::display_list::DisplayList;
 use clap::{clap_app, crate_version};
 use metamath_knife::database::{Database, DbOptions};
 use metamath_knife::diag::{BibError, DiagnosticClass};
+use metamath_knife::statement::StatementAddress;
 use metamath_knife::verify_markup::{Bibliography, Bibliography2};
 use metamath_knife::SourceInfo;
 use simple_logger::SimpleLogger;
@@ -29,6 +30,7 @@ fn main() {
         (@arg timing: --timing "Print milliseconds after each stage")
         (@arg verify: -v --verify "Check proof validity")
         (@arg verify_markup: -m --("verify-markup") "Check comment markup")
+        (@arg discouraged: -D --discouraged "Regenerate `discouraged` file")
         (@arg outline: -O --outline "Show database outline")
         (@arg print_typesetting: --("dump-typesetting") "Show typesetting information")
         (@arg parse_typesetting: -t --("parse-typesetting") "Parse typesetting information")
@@ -117,7 +119,13 @@ fn main() {
             db.verify_parse_stmt();
         }
 
-        let diags = db.diag_notations(&types);
+        let mut diags = db.diag_notations(&types);
+
+        if matches.is_present("discouraged") {
+            db.regen_discouraged()
+                .unwrap_or_else(|diag| diags.push((StatementAddress::default(), diag)));
+        }
+
         let mut count = db
             .render_diags(diags, |snippet| {
                 println!("{}", DisplayList::from(snippet));


### PR DESCRIPTION
This adds a `-D` or `--discouraged` flag to the command line version of the tool to generate the `discouraged` file, in the same format as metamath.exe.