### PR TITLE
Verbs for command line help, README, and Misc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ Alternatively using `cargo install`:
     git clone https://github.com/metamath/set.mm
 
     # One-shot verification using 4 threads
-    target/release/metamath-knife --timing --jobs 4 --split --verify set.mm/set.mm
+    target/release/metamath-knife --time --jobs 4 --split --verify set.mm/set.mm
 
     # Incremental verification
-    (while sleep 5; do echo; done) | target/release/metamath-knife --timing --jobs 4 --split --repeat --trace-recalc --verify set.mm/set.mm
+    (while sleep 5; do echo; done) | target/release/metamath-knife --time --jobs 4 --split --repeat --trace-recalc --verify set.mm/set.mm
     # then make small changes to the beginning, end, or middle of the DB and observe how behavior changes
 
 Here is the command line help, which gives an idea of the options available:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Metamath-knife is a friendly fork of
 
 ## Building
 
-Install Rust, "Rust 2018" (version 1.31.0) or later, then check out this repository and run:
+Install Rust, "Rust 2021" (version 1.56.0) or later, preferably using (rustup)[https://rustup.rs], then check out this repository and run:
 
     cargo build --release
 
@@ -43,6 +43,45 @@ Alternatively using `cargo install`:
     # Incremental verification
     (while sleep 5; do echo; done) | target/release/metamath-knife --timing --jobs 4 --split --repeat --trace-recalc --verify set.mm/set.mm
     # then make small changes to the beginning, end, or middle of the DB and observe how behavior changes
+
+Here is the command line help, which gives an idea of the options available:
+```
+A Metamath database verifier and processing tool
+
+USAGE:
+    metamath-knife [FLAGS] [OPTIONS] <DATABASE>
+
+FLAGS:
+        --debug                Activates debug logs, including for the grammar building and statement parsing
+        --free                 Explicitly deallocates working memory before exit
+    -g, --grammar              Checks grammar
+    -h, --help                 Prints help information
+    -O, --outline              Shows database outline
+    -p, --parse-stmt           Parses all statements according to the database's grammar
+    -t, --parse-typesetting    Parses typesetting information
+    -F, --print-formula        Dumps the formulas of this database
+    -G, --print-grammar        Prints the database's grammar
+        --dump-typesetting     Shows typesetting information
+        --repeat               Demonstrates incremental verifier
+        --split                Processes files > 1 MiB in multiple segments
+        --timing               Prints milliseconds after each stage
+        --trace-recalc         Prints segments as they are recalculated
+    -V, --version              Prints version information
+    -v, --verify               Checks proof validity
+    -m, --verify-markup        Checks comment markup
+        --verify-parse-stmt    Checks that printing parsed statements gives back the original formulas
+
+OPTIONS:
+        --text <NAME> <TEXT>    Provides raw database content on the command line
+        --biblio <FILE>...      Supplies a bibliography file for verify-markup
+                                Can be used one or two times; the second is for exthtml processing
+    -D, --discouraged <FILE>    Regenerates `discouraged` file
+    -e, --export <LABEL>...     Outputs a proof file
+    -j, --jobs <jobs>           Number of threads to use for verification
+
+ARGS:
+    <DATABASE>    Database file to load
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -53,18 +53,18 @@ USAGE:
 
 FLAGS:
         --debug                Activates debug logs, including for the grammar building and statement parsing
+    -F, --dump-formula         Dumps the formulas of this database
+    -G, --dump-grammar         Dumps the database's grammar
+    -T, --dump-typesetting     Dumps typesetting information
         --free                 Explicitly deallocates working memory before exit
     -g, --grammar              Checks grammar
     -h, --help                 Prints help information
     -O, --outline              Shows database outline
     -p, --parse-stmt           Parses all statements according to the database's grammar
     -t, --parse-typesetting    Parses typesetting information
-    -F, --print-formula        Dumps the formulas of this database
-    -G, --print-grammar        Prints the database's grammar
-        --dump-typesetting     Shows typesetting information
         --repeat               Demonstrates incremental verifier
         --split                Processes files > 1 MiB in multiple segments
-        --timing               Prints milliseconds after each stage
+        --time                 Prints milliseconds after each stage
         --trace-recalc         Prints segments as they are recalculated
     -V, --version              Prints version information
     -v, --verify               Checks proof validity

--- a/src/database.rs
+++ b/src/database.rs
@@ -842,16 +842,16 @@ impl Database {
 
     /// Dump the grammar of this database.
     /// Requires: [`Database::name_pass`], [`Database::grammar_pass`]
-    pub fn print_grammar(&self) {
-        time(&self.options, "print_grammar", || {
+    pub fn dump_grammar(&self) {
+        time(&self.options, "dump_grammar", || {
             self.grammar_result().dump(self);
         })
     }
 
     /// Dump the formulas of this database.
     /// Requires: [`Database::name_pass`], [`Database::stmt_parse_pass`]
-    pub fn print_formula(&self) {
-        time(&self.options, "print_formulas", || {
+    pub fn dump_formula(&self) {
+        time(&self.options, "dump_formulas", || {
             self.stmt_parse_result().dump(self);
         })
     }

--- a/src/database.rs
+++ b/src/database.rs
@@ -527,7 +527,7 @@ impl Database {
     #[must_use]
     pub fn name_result(&self) -> &Arc<Nameset> {
         self.nameset.as_ref().expect(
-            "The database has not run `name_pass()`. Please ensure it is run before calling depdending methods."
+            "The database has not run `name_pass()`. Please ensure it is run before calling depending methods."
         )
     }
 
@@ -560,7 +560,7 @@ impl Database {
     #[must_use]
     pub fn scope_result(&self) -> &Arc<ScopeResult> {
         self.scopes.as_ref().expect(
-            "The database has not run `scope_pass()`. Please ensure it is run before calling depdending methods."
+            "The database has not run `scope_pass()`. Please ensure it is run before calling depending methods."
         )
     }
 
@@ -594,7 +594,7 @@ impl Database {
     #[must_use]
     pub fn verify_result(&self) -> &Arc<VerifyResult> {
         self.verify.as_ref().expect(
-            "The database has not run `verify_pass()`. Please ensure it is run before calling depdending methods."
+            "The database has not run `verify_pass()`. Please ensure it is run before calling depending methods."
         )
     }
 
@@ -615,7 +615,7 @@ impl Database {
     #[must_use]
     pub fn typesetting_result(&self) -> &Arc<TypesettingData> {
         self.typesetting.as_ref().expect(
-            "The database has not run `typesetting_pass()`. Please ensure it is run before calling depdending methods."
+            "The database has not run `typesetting_pass()`. Please ensure it is run before calling depending methods."
         )
     }
 
@@ -636,7 +636,7 @@ impl Database {
     #[must_use]
     pub fn outline_result(&self) -> &Arc<Outline> {
         self.outline.as_ref().expect(
-            "The database has not run `outline_pass()`. Please ensure it is run before calling depdending methods."
+            "The database has not run `outline_pass()`. Please ensure it is run before calling depending methods."
         )
     }
 
@@ -658,7 +658,7 @@ impl Database {
     #[must_use]
     pub fn grammar_result(&self) -> &Arc<Grammar> {
         self.grammar.as_ref().expect(
-            "The database has not run `grammar_pass()`. Please ensure it is run before calling depdending methods."
+            "The database has not run `grammar_pass()`. Please ensure it is run before calling depending methods."
         )
     }
 
@@ -686,7 +686,7 @@ impl Database {
     #[must_use]
     pub fn stmt_parse_result(&self) -> &Arc<StmtParse> {
         self.stmt_parse.as_ref().expect(
-            "The database has not run `stmt_parse_pass()`. Please ensure it is run before calling depdending methods."
+            "The database has not run `stmt_parse_pass()`. Please ensure it is run before calling depending methods."
         )
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,20 +28,20 @@ fn main() {
         (@arg TEXT: --text value_names(&["NAME", "TEXT"]) ...
             "Provides raw database content on the command line")
         (@arg split: --split "Processes files > 1 MiB in multiple segments")
-        (@arg timing: --timing "Prints milliseconds after each stage")
+        (@arg timing: --time "Prints milliseconds after each stage")
         (@arg verify: -v --verify "Checks proof validity")
         (@arg verify_markup: -m --("verify-markup") "Checks comment markup")
         (@arg discouraged: -D --discouraged [FILE] "Regenerates `discouraged` file")
         (@arg outline: -O --outline "Shows database outline")
-        (@arg print_typesetting: --("dump-typesetting") "Shows typesetting information")
+        (@arg dump_typesetting: -T --("dump-typesetting") "Dumps typesetting information")
         (@arg parse_typesetting: -t --("parse-typesetting") "Parses typesetting information")
         (@arg grammar: -g --grammar "Checks grammar")
         (@arg parse_stmt: -p --("parse-stmt")
             "Parses all statements according to the database's grammar")
         (@arg verify_parse_stmt: --("verify-parse-stmt")
             "Checks that printing parsed statements gives back the original formulas")
-        (@arg print_grammar: -G --("print-grammar") "Prints the database's grammar")
-        (@arg print_formula: -F --("print-formula") "Dumps the formulas of this database")
+        (@arg dump_grammar: -G --("dump-grammar") "Dumps the database's grammar")
+        (@arg dump_formula: -F --("dump-formula") "Dumps the formulas of this database")
         (@arg debug: --debug
             "Activates debug logs, including for the grammar building and statement parsing")
         (@arg trace_recalc: --("trace-recalc") "Prints segments as they are recalculated")
@@ -71,8 +71,8 @@ fn main() {
             || matches.is_present("parse_stmt")
             || matches.is_present("verify_parse_stmt")
             || matches.is_present("export_grammar_dot")
-            || matches.is_present("print_grammar")
-            || matches.is_present("print_formula"),
+            || matches.is_present("dump_grammar")
+            || matches.is_present("dump_formula"),
         jobs: usize::from_str(matches.value_of("jobs").unwrap_or("1"))
             .expect("validator should check this"),
     };
@@ -174,9 +174,9 @@ fn main() {
 
         println!("{count} diagnostics issued.");
 
-        if matches.is_present("print_grammar") {
+        if matches.is_present("dump_grammar") {
             db.grammar_pass();
-            db.print_grammar();
+            db.dump_grammar();
         }
 
         #[cfg(feature = "dot")]
@@ -184,8 +184,9 @@ fn main() {
             db.export_grammar_dot();
         }
 
-        if matches.is_present("print_formula") {
-            db.print_formula();
+        if matches.is_present("dump_formula") {
+            db.stmt_parse_pass();
+            db.dump_formula();
         }
 
         if matches.is_present("outline") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,31 +26,31 @@ fn main() {
         (about: "A Metamath database verifier and processing tool")
         (@arg DATABASE: required_unless("TEXT") "Database file to load")
         (@arg TEXT: --text value_names(&["NAME", "TEXT"]) ...
-            "Provide raw database content on the command line")
-        (@arg split: --split "Process files > 1 MiB in multiple segments")
-        (@arg timing: --timing "Print milliseconds after each stage")
-        (@arg verify: -v --verify "Check proof validity")
-        (@arg verify_markup: -m --("verify-markup") "Check comment markup")
-        (@arg discouraged: -D --discouraged [FILE] "Regenerate `discouraged` file")
-        (@arg outline: -O --outline "Show database outline")
-        (@arg print_typesetting: --("dump-typesetting") "Show typesetting information")
-        (@arg parse_typesetting: -t --("parse-typesetting") "Parse typesetting information")
-        (@arg grammar: -g --grammar "Check grammar")
+            "Provides raw database content on the command line")
+        (@arg split: --split "Processes files > 1 MiB in multiple segments")
+        (@arg timing: --timing "Prints milliseconds after each stage")
+        (@arg verify: -v --verify "Checks proof validity")
+        (@arg verify_markup: -m --("verify-markup") "Checks comment markup")
+        (@arg discouraged: -D --discouraged [FILE] "Regenerates `discouraged` file")
+        (@arg outline: -O --outline "Shows database outline")
+        (@arg print_typesetting: --("dump-typesetting") "Shows typesetting information")
+        (@arg parse_typesetting: -t --("parse-typesetting") "Parses typesetting information")
+        (@arg grammar: -g --grammar "Checks grammar")
         (@arg parse_stmt: -p --("parse-stmt")
-            "Parse all statements according to the database's grammar")
+            "Parses all statements according to the database's grammar")
         (@arg verify_parse_stmt: --("verify-parse-stmt")
-            "Check that printing parsed statements gives back the original formulas")
-        (@arg print_grammar: -G --("print-grammar") "Print the database's grammar")
-        (@arg print_formula: -F --("print-formula") "Dump the formulas of this database")
+            "Checks that printing parsed statements gives back the original formulas")
+        (@arg print_grammar: -G --("print-grammar") "Prints the database's grammar")
+        (@arg print_formula: -F --("print-formula") "Dumps the formulas of this database")
         (@arg debug: --debug
-            "Activate debug logs, including for the grammar building and statement parsing")
-        (@arg trace_recalc: --("trace-recalc") "Print segments as they are recalculated")
-        (@arg free: --free "Explicitly deallocate working memory before exit")
-        (@arg repeat: --repeat "Demonstrate incremental verifier")
+            "Activates debug logs, including for the grammar building and statement parsing")
+        (@arg trace_recalc: --("trace-recalc") "Prints segments as they are recalculated")
+        (@arg free: --free "Explicitly deallocates working memory before exit")
+        (@arg repeat: --repeat "Demonstrates incremental verifier")
         (@arg jobs: -j --jobs +takes_value validator(positive_integer)
             "Number of threads to use for verification")
-        (@arg export: -e --export [LABEL] ... "Output a proof file")
-        (@arg biblio: --biblio [FILE] ... "Supply a bibliography file for verify-markup\n\
+        (@arg export: -e --export [LABEL] ... "Outputs a proof file")
+        (@arg biblio: --biblio [FILE] ... "Supplies a bibliography file for verify-markup\n\
             Can be used one or two times; the second is for exthtml processing")
     );
 
@@ -175,6 +175,7 @@ fn main() {
         println!("{count} diagnostics issued.");
 
         if matches.is_present("print_grammar") {
+            db.grammar_pass();
             db.print_grammar();
         }
 


### PR DESCRIPTION
@benjub [mentioned](https://github.com/david-a-wheeler/metamath-knife/pull/96#issuecomment-1436529780) that some verbs in the command line help are "Prints" instead of "Print". Actually those two exceptions are for help and version, which are automatically generated by the `clap` crate. So I instead changed all our option descriptions so that they are verbs at the 3rd person.

Also, fixes #101 by running a grammar pass before printing the grammar.
