### PR TITLE
[DRAFT] Begin adding the ability to verify definitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bstr"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ffdb39cb703212f3c11973452c2861b972f757b021158f3516ba10f2fa8b2c1"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -129,6 +139,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "globset"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,6 +205,7 @@ dependencies = [
  "dot-writer",
  "filetime",
  "fnv",
+ "globset",
  "itertools",
  "lazy_static",
  "log",
@@ -235,6 +259,12 @@ name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "serde"
+version = "1.0.152"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 
 [[package]]
 name = "simple_logger"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ tinyvec = "1.5"
 log = "0.4"
 annotate-snippets = "0.9"
 typed-arena = "2.0"
+# TODO: Globset will probably be removed once other capabilities are in place.
 globset = "0.4.10"
 
 # Dependencies for standalone executable, not needed for a library

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ tinyvec = "1.5"
 log = "0.4"
 annotate-snippets = "0.9"
 typed-arena = "2.0"
+globset = "0.4.10"
 
 # Dependencies for standalone executable, not needed for a library
 clap = "2.33"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,7 @@ pub mod scopeck;
 pub mod statement;
 pub mod typesetting;
 pub mod verify;
+pub mod verify_definitions;
 pub mod verify_markup;
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,11 +127,9 @@ fn main() {
         let mut diags = db.diag_notations(&types);
 
         if matches.is_present("discouraged") {
-            (|| {
-                let file = File::create(matches.value_of("discouraged").unwrap())?;
-                db.write_discouraged(&mut BufWriter::new(file))
-            })()
-            .unwrap_or_else(|diag| diags.push((StatementAddress::default(), diag.into())));
+            File::create(matches.value_of("discouraged").unwrap())
+                .and_then(|file| db.write_discouraged(&mut BufWriter::new(file)))
+                .unwrap_or_else(|err| diags.push((StatementAddress::default(), err.into())));
         }
 
         let mut count = db

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,9 +31,12 @@ fn main() {
         (@arg timing: --time "Prints milliseconds after each stage")
         (@arg verify: -v --verify "Checks proof validity")
         (@arg verify_markup: -m --("verify-markup") "Checks comment markup")
-        (@arg verify_definitions: --("verify-definitions") [EXCLUSIONS]
-            default_value("ax-*,df-bi,df-clab,df-cleq,df-clel")
-            "Checks definitions except for exclusions list")
+        (@arg verify_definitions: --("verify-definitions")
+               "Verifies definitions per the conventions of set.mm")
+        // TODO: Used for early testing, eventually this option will disappear:
+        (@arg definition_exclusions: --("definition-exclusions") [EXCLUSIONS]
+           default_value("ax-*,df-bi,df-clab,df-cleq,df-clel")
+           "Changes the definition exclusions from their set.mm defaults")
         (@arg discouraged: -D --discouraged [FILE] "Regenerates `discouraged` file")
         (@arg outline: -O --outline "Shows database outline")
         (@arg dump_typesetting: -T --("dump-typesetting") "Dumps typesetting information")
@@ -142,7 +145,7 @@ fn main() {
             .len();
 
         if matches.is_present("verify_definitions") {
-            let list = matches.value_of("verify_definitions").unwrap();
+            let list = matches.value_of("definition_exclusions").unwrap();
             let diags = db.verify_definitions(list);
             count += db
                 .render_diags(diags, |snippet| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use metamath_knife::database::{Database, DbOptions};
 use metamath_knife::diag::{BibError, DiagnosticClass};
 use metamath_knife::statement::StatementAddress;
 use metamath_knife::verify_markup::{Bibliography, Bibliography2};
+// use metamath_knife::verify_definitions; // ::verify_definitions;
 use metamath_knife::SourceInfo;
 use simple_logger::SimpleLogger;
 use std::fs::File;
@@ -31,6 +32,8 @@ fn main() {
         (@arg timing: --timing "Print milliseconds after each stage")
         (@arg verify: -v --verify "Check proof validity")
         (@arg verify_markup: -m --("verify-markup") "Check comment markup")
+        (@arg verify_definitions: --("verify-definitions") [EXCLUSIONS]
+            "Check definitions except for exclusions list")
         (@arg discouraged: -D --discouraged [FILE] "Regenerate `discouraged` file")
         (@arg outline: -O --outline "Show database outline")
         (@arg print_typesetting: --("dump-typesetting") "Show typesetting information")
@@ -137,6 +140,16 @@ fn main() {
                 println!("{}", DisplayList::from(snippet));
             })
             .len();
+
+        if matches.is_present("verify_definitions") {
+            let list = matches.value_of("verify_definitions").unwrap();
+            let diags = db.verify_definitions(&list);
+            count += db
+                .render_diags(diags, |snippet| {
+                    println!("{}", DisplayList::from(snippet));
+                })
+                .len();
+        }
 
         if matches.is_present("verify_markup") {
             db.scope_pass();

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,6 @@ use metamath_knife::database::{Database, DbOptions};
 use metamath_knife::diag::{BibError, DiagnosticClass};
 use metamath_knife::statement::StatementAddress;
 use metamath_knife::verify_markup::{Bibliography, Bibliography2};
-// use metamath_knife::verify_definitions; // ::verify_definitions;
 use metamath_knife::SourceInfo;
 use simple_logger::SimpleLogger;
 use std::fs::File;
@@ -33,6 +32,7 @@ fn main() {
         (@arg verify: -v --verify "Checks proof validity")
         (@arg verify_markup: -m --("verify-markup") "Checks comment markup")
         (@arg verify_definitions: --("verify-definitions") [EXCLUSIONS]
+            default_value("ax-*,df-bi,df-clab,df-cleq,df-clel")
             "Checks definitions except for exclusions list")
         (@arg discouraged: -D --discouraged [FILE] "Regenerates `discouraged` file")
         (@arg outline: -O --outline "Shows database outline")

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,7 +143,7 @@ fn main() {
 
         if matches.is_present("verify_definitions") {
             let list = matches.value_of("verify_definitions").unwrap();
-            let diags = db.verify_definitions(&list);
+            let diags = db.verify_definitions(list);
             count += db
                 .render_diags(diags, |snippet| {
                     println!("{}", DisplayList::from(snippet));

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -633,6 +633,14 @@ impl<'a> StatementRef<'a> {
         }
     }
 
+    /// Return the statement's typecode (the first token in the math string).
+    /// This function is only useful if there is a math string!
+    #[inline]
+    #[must_use]
+    pub fn typecode(&self) -> TokenRef<'a> {
+        self.math_at(0)
+    }
+
     /// Obtains textual proof data by token index.
     #[inline]
     #[must_use]

--- a/src/verify_definitions.rs
+++ b/src/verify_definitions.rs
@@ -11,6 +11,7 @@
 //! and "Metamath: A Computer Language for Mathematical Proofs" by
 //! Norman Megill and David A. Wheeler, 2019, page 155.
 
+use crate::as_str;
 use crate::diag::Diagnostic;
 use crate::statement::StatementAddress;
 use crate::{Database, StatementRef, StatementType};
@@ -21,9 +22,8 @@ use globset::{Glob, GlobSetBuilder};
 fn verify_definition_statement(stmt: &StatementRef<'_>) -> Option<Diagnostic> {
     // Rule 1: New definitions must be introduced using = or <->
     // TODO
-    if let Ok(label) = std::str::from_utf8(stmt.label()) {
-        println!(" Need to check: $a statement {label}");
-    }
+    let label = as_str(stmt.label());
+    println!(" Need to check: $a statement {label}");
 
     None
 }
@@ -68,13 +68,12 @@ impl Database {
                 let typecode = stmt.typecode();
                 if *typecode == *typecode_provable {
                     // Typecode is |-
-                    if let Ok(label) = std::str::from_utf8(stmt.label()) {
-                        if !compiled_exceptions.is_match(label) {
-                            // println!("DEBUG: Processing $a {}", label);
-                            let result = verify_definition_statement(&stmt);
-                            if let Some(problem) = result {
-                                diags.push((stmt.address(), problem));
-                            }
+                    let label = as_str(stmt.label());
+                    if !compiled_exceptions.is_match(label) {
+                        // println!("DEBUG: Processing $a {}", label);
+                        let result = verify_definition_statement(&stmt);
+                        if let Some(problem) = result {
+                            diags.push((stmt.address(), problem));
                         }
                     }
                 }

--- a/src/verify_definitions.rs
+++ b/src/verify_definitions.rs
@@ -3,11 +3,11 @@
 //! Implement verification of definitions per the set.mm/iset.mm conventions.
 //! If the "exceptions" string is empty we use the "typical" set.mm values.
 //! The current typical values are "ax-*,df-bi,df-clab,df-cleq,df-clel".
-//! For glob syntax see: https://docs.rs/globset/latest/globset/
+//! For glob syntax see: <https://docs.rs/globset/latest/globset/>
 //! but in the future we may reduce the glob language sophistication.
 //! For more information see:
-//! https://us.metamath.org/mpeuni/conventions.html
-//! https://github.com/digama0/mmj2/blob/master/mmj2jar/macros/definitionCheck.js
+//! <https://us.metamath.org/mpeuni/conventions.html>
+//! <https://github.com/digama0/mmj2/blob/master/mmj2jar/macros/definitionCheck.js>
 //! and "Metamath: A Computer Language for Mathematical Proofs" by
 //! Norman Megill and David A. Wheeler, 2019, page 155.
 
@@ -22,7 +22,7 @@ fn verify_definition_statement(stmt: &StatementRef<'_>) -> Option<Diagnostic> {
     // Rule 1: New definitions must be introduced using = or <->
     // TODO
     if let Ok(label) = std::str::from_utf8(stmt.label()) {
-        println!(" Need to check: $a statement {}", label);
+        println!(" Need to check: $a statement {label}");
     }
 
     None
@@ -39,7 +39,7 @@ impl Database {
         } else {
             exceptions
         };
-        let vector_exceptions: Vec<&str> = exceptions_str.split(",").collect();
+        let vector_exceptions: Vec<&str> = exceptions_str.split(',').collect();
 
         // Compile the glob patterns before using them in a loop.
         // The Rust glob libraries only support &str, not [u8] byte arrays,
@@ -55,26 +55,26 @@ impl Database {
         }
         let compiled_exceptions = builder.build().unwrap();
 
-        let typecode_provable = "|-".as_bytes();
+        let typecode_provable = b"|-";
 
         for stmt in self.statements() {
-            match stmt.statement_type() {
-                StatementType::Axiom => {
-                    if let Some(typecode) = stmt.math_iter().next() {
-                        if *typecode == *typecode_provable { // Typecode is |-
-                            if let Ok(label) = std::str::from_utf8(stmt.label()) {
-                                if !compiled_exceptions.is_match(label) {
-                                    // println!("DEBUG: Processing $a {}", label);
-                                    let result = verify_definition_statement(&stmt);
-                                    if let Some(problem) = result {
-                                        diags.push((stmt.address(), problem));
-                                    }
+            // match stmt.statement_type() { StatementType::Axiom => { .. } }
+
+            if stmt.statement_type() == StatementType::Axiom {
+                if let Some(typecode) = stmt.math_iter().next() {
+                    if *typecode == *typecode_provable {
+                        // Typecode is |-
+                        if let Ok(label) = std::str::from_utf8(stmt.label()) {
+                            if !compiled_exceptions.is_match(label) {
+                                // println!("DEBUG: Processing $a {}", label);
+                                let result = verify_definition_statement(&stmt);
+                                if let Some(problem) = result {
+                                    diags.push((stmt.address(), problem));
                                 }
                             }
                         }
                     }
                 }
-                _ => {} // TODO: Non-axioms
             }
         }
         diags

--- a/src/verify_definitions.rs
+++ b/src/verify_definitions.rs
@@ -1,0 +1,82 @@
+//! Verification of definitions
+//!
+//! Implement verification of definitions per the set.mm/iset.mm conventions.
+//! If the "exceptions" string is empty we use the "typical" set.mm values.
+//! The current typical values are "ax-*,df-bi,df-clab,df-cleq,df-clel".
+//! For glob syntax see: https://docs.rs/globset/latest/globset/
+//! but in the future we may reduce the glob language sophistication.
+//! For more information see:
+//! https://us.metamath.org/mpeuni/conventions.html
+//! https://github.com/digama0/mmj2/blob/master/mmj2jar/macros/definitionCheck.js
+//! and "Metamath: A Computer Language for Mathematical Proofs" by
+//! Norman Megill and David A. Wheeler, 2019, page 155.
+
+use crate::diag::Diagnostic;
+use crate::statement::StatementAddress;
+use crate::{Database, StatementRef, StatementType};
+use globset::{Glob, GlobSetBuilder};
+
+/// Verify the definition in this statement.
+/// Return a diagnostic if there's a problem, else None for no problem.
+fn verify_definition_statement(stmt: &StatementRef<'_>) -> Option<Diagnostic> {
+    // Rule 1: New definitions must be introduced using = or <->
+    // TODO
+    if let Ok(label) = std::str::from_utf8(stmt.label()) {
+        println!(" Need to check: $a statement {}", label);
+    }
+
+    None
+}
+
+impl Database {
+    /// Verify that definitions meet set.mm/iset.mm conventions;
+    /// exclude *exceptions* from this check.
+    #[must_use]
+    pub fn verify_definitions(&self, exceptions: &str) -> Vec<(StatementAddress, Diagnostic)> {
+        let mut diags = vec![];
+        let exceptions_str = if exceptions.is_empty() {
+            "ax-*,df-bi,df-clab,df-cleq,df-clel" // Default for set.mm.
+        } else {
+            exceptions
+        };
+        let vector_exceptions: Vec<&str> = exceptions_str.split(",").collect();
+
+        // Compile the glob patterns before using them in a loop.
+        // The Rust glob libraries only support &str, not [u8] byte arrays,
+        // so we will convert every label to &str to use a glob library.
+        // This causes some unnecessary overhead, but it's less code to write.
+        // The Rust glob libraries are absurdly over-featured for our use case
+        // *and* can't handle [u8]. In the future we might replace this with
+        // a function that meets our needs and stop using this library.
+        let mut builder = GlobSetBuilder::new();
+        for exception in vector_exceptions {
+            let glob = Glob::new(exception).expect("Failed to compile pattern");
+            builder.add(glob);
+        }
+        let compiled_exceptions = builder.build().unwrap();
+
+        let typecode_provable = "|-".as_bytes();
+
+        for stmt in self.statements() {
+            match stmt.statement_type() {
+                StatementType::Axiom => {
+                    if let Some(typecode) = stmt.math_iter().next() {
+                        if *typecode == *typecode_provable { // Typecode is |-
+                            if let Ok(label) = std::str::from_utf8(stmt.label()) {
+                                if !compiled_exceptions.is_match(label) {
+                                    // println!("DEBUG: Processing $a {}", label);
+                                    let result = verify_definition_statement(&stmt);
+                                    if let Some(problem) = result {
+                                        diags.push((stmt.address(), problem));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                _ => {} // TODO: Non-axioms
+            }
+        }
+        diags
+    }
+}

--- a/src/verify_definitions.rs
+++ b/src/verify_definitions.rs
@@ -31,23 +31,20 @@ fn verify_definition_statement(stmt: &StatementRef<'_>) -> Option<Diagnostic> {
 impl Database {
     /// Verify that definitions meet set.mm/iset.mm conventions;
     /// exclude *exceptions* from this check.
+    /// TODO: Eventually we'll eliminate the "exceptions" glob pattern list,
+    /// but this gets us started.
     #[must_use]
     pub fn verify_definitions(&self, exceptions: &str) -> Vec<(StatementAddress, Diagnostic)> {
         let mut diags = vec![];
-        let exceptions_str = if exceptions.is_empty() {
-            "ax-*,df-bi,df-clab,df-cleq,df-clel" // Default for set.mm.
-        } else {
-            exceptions
-        };
-        let vector_exceptions: Vec<&str> = exceptions_str.split(',').collect();
+        let vector_exceptions: Vec<&str> = exceptions.split(',').collect();
 
         // Compile the glob patterns before using them in a loop.
         // The Rust glob libraries only support &str, not [u8] byte arrays,
         // so we will convert every label to &str to use a glob library.
         // This causes some unnecessary overhead, but it's less code to write.
         // The Rust glob libraries are absurdly over-featured for our use case
-        // *and* can't handle [u8]. In the future we might replace this with
-        // a function that meets our needs and stop using this library.
+        // *and* can't handle [u8]. In the future the plan is to stop using
+        // globs entirely, and use data from $j statements.
         let mut builder = GlobSetBuilder::new();
         for exception in vector_exceptions {
             let glob = Glob::new(exception).expect("Failed to compile pattern");
@@ -55,22 +52,28 @@ impl Database {
         }
         let compiled_exceptions = builder.build().unwrap();
 
+        // TODO: Eventually this should be acquired from the database.
+        // The grammar pass is getting the provable type code from the
+        // $j comment. However, the grammar pass is not always required
+        // when the provable type code is.
+        // Maybe a more suitable place would be directly in database?
+        // Maybe there should be centralized and buffered accessors for
+        // all $j commands?
         let typecode_provable = b"|-";
 
         for stmt in self.statements() {
             // match stmt.statement_type() { StatementType::Axiom => { .. } }
 
             if stmt.statement_type() == StatementType::Axiom {
-                if let Some(typecode) = stmt.math_iter().next() {
-                    if *typecode == *typecode_provable {
-                        // Typecode is |-
-                        if let Ok(label) = std::str::from_utf8(stmt.label()) {
-                            if !compiled_exceptions.is_match(label) {
-                                // println!("DEBUG: Processing $a {}", label);
-                                let result = verify_definition_statement(&stmt);
-                                if let Some(problem) = result {
-                                    diags.push((stmt.address(), problem));
-                                }
+                let typecode = stmt.typecode();
+                if *typecode == *typecode_provable {
+                    // Typecode is |-
+                    if let Ok(label) = std::str::from_utf8(stmt.label()) {
+                        if !compiled_exceptions.is_match(label) {
+                            // println!("DEBUG: Processing $a {}", label);
+                            let result = verify_definition_statement(&stmt);
+                            if let Some(problem) = result {
+                                diags.push((stmt.address(), problem));
                             }
                         }
                     }


### PR DESCRIPTION
This adds a --verify-definitions 'globlist' option to the set of options and starting code to implement it.

This version doesn't actually perform the check, it instead simply prints as the names of the statements to check. More importantly, it begins setting up the code infrastructure so we can implement the definitions check "for real".