### PR TITLE
Formula typecode converter

### DIFF
--- a/src/formula.rs
+++ b/src/formula.rs
@@ -762,6 +762,17 @@ pub(crate) struct FormulaBuilder {
 
 /// A utility to build a formula.
 impl FormulaBuilder {
+    pub(crate) fn from_formula(fmla: Formula) -> Self {
+        let stack = vec![fmla.root];
+        let tree = (*fmla.tree).clone();
+        let variables = fmla.variables;
+        FormulaBuilder {
+            stack,
+            variables,
+            tree,
+        }
+    }
+
     /// Every REDUCE pops `var_count` subformula items on the stack,
     /// and pushes one single new item, with the popped subformulas as children
     pub(crate) fn reduce(&mut self, label: Label, var_count: u8, offset: u8, is_variable: bool) {

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -1506,6 +1506,21 @@ impl Grammar {
         self.logic_type
     }
 
+    /// Converts the given formula to the tatget typecode,
+    /// provided there is a suitable type conversion.
+    #[must_use]
+    pub fn convert_typecode(&self, fmla: Formula, target_tc: TypeCode) -> Option<Formula> {
+        let source_tc = fmla.get_typecode();
+        self.type_conversions
+            .iter()
+            .find(|(from_tc, to_tc, _)| *from_tc == source_tc && *to_tc == target_tc)
+            .map(|(_, _, label)| {
+                let mut builder = FormulaBuilder::from_formula(fmla);
+                builder.reduce(*label, 1, 0, false);
+                builder.build(target_tc)
+            })
+    }
+
     /// Lists the contents of the grammar's parse table. This can be used for debugging.
     pub fn dump(&self, db: &Database) {
         println!("Grammar tree has {:?} nodes.", self.nodes.len());

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ fn main() {
         (@arg timing: --time "Prints milliseconds after each stage")
         (@arg verify: -v --verify "Checks proof validity")
         (@arg verify_markup: -m --("verify-markup") "Checks comment markup")
-        (@arg discouraged: -D --discouraged [FILE] "Regenerates `discouraged` file")
+        (@arg discouraged: -D --discouraged [FILE] default_value("discouraged") "Regenerates `discouraged` file")
         (@arg outline: -O --outline "Shows database outline")
         (@arg dump_typesetting: -T --("dump-typesetting") "Dumps typesetting information")
         (@arg parse_typesetting: -t --("parse-typesetting") "Parses typesetting information")

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ fn main() {
         (@arg timing: --time "Prints milliseconds after each stage")
         (@arg verify: -v --verify "Checks proof validity")
         (@arg verify_markup: -m --("verify-markup") "Checks comment markup")
-        (@arg discouraged: -D --discouraged [FILE] default_value("discouraged") "Regenerates `discouraged` file")
+        (@arg discouraged: -D --discouraged [FILE] "Regenerates `discouraged` file")
         (@arg outline: -O --outline "Shows database outline")
         (@arg dump_typesetting: -T --("dump-typesetting") "Dumps typesetting information")
         (@arg parse_typesetting: -t --("parse-typesetting") "Parses typesetting information")


### PR DESCRIPTION
Adds a new public API `convert_typecode` to convert a formula to a given typecode.
This is typically used to convert a formula with typecode `set` to `class`.