### PR TITLE
Commands

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,0 +1,48 @@
+//! A parser for the different `$j` commands of the database
+//! Currently supports:
+//! - `syntax`
+use crate::{formula::TypeCode, nameck::Nameset, segment_set::SegmentSet, statement::CommandToken};
+
+/// Parser commands for the database
+#[derive(Debug)]
+pub struct Commands {
+    /// The provable type, typically `|-`
+    pub provable_type: TypeCode,
+    /// The logical type, typically `wff`
+    pub logic_type: TypeCode,
+    /// A list of all typecodes, e.g. `wff`, `class`, `setvar`
+    pub typecodes: Vec<TypeCode>,
+}
+
+impl Commands {
+    /// Parses the commands
+    pub(crate) fn new(sset: &SegmentSet, nset: &Nameset) -> Self {
+        let mut provable_type = TypeCode::default();
+        let mut logic_type = TypeCode::default();
+        let mut typecodes = vec![];
+        for sref in sset.segments(..) {
+            let buf = &**sref.buffer;
+            for (_, (_, command)) in &sref.j_commands {
+                use CommandToken::*;
+                match &**command {
+                    [Keyword(cmd), sort, Keyword(as_), logic]
+                        if cmd.as_ref(buf) == b"syntax" && as_.as_ref(buf) == b"as" =>
+                    {
+                        provable_type = nset.lookup_symbol(sort.value(buf)).unwrap().atom;
+                        logic_type = nset.lookup_symbol(logic.value(buf)).unwrap().atom;
+                        typecodes.push(logic_type);
+                    }
+                    [Keyword(cmd), sort] if cmd.as_ref(buf) == b"syntax" => {
+                        typecodes.push(nset.lookup_symbol(sort.value(buf)).unwrap().atom)
+                    }
+                    _ => {}
+                }
+            }
+        }
+        Commands {
+            provable_type,
+            logic_type,
+            typecodes,
+        }
+    }
+}

--- a/src/database.rs
+++ b/src/database.rs
@@ -98,6 +98,7 @@
 //! estimated runtime.  This requires an additional argument when queueing.
 
 use crate::as_str;
+use crate::commands::Commands;
 use crate::diag;
 use crate::diag::Diagnostic;
 use crate::diag::DiagnosticClass;
@@ -401,6 +402,7 @@ pub struct Database {
     outline: Option<Arc<Outline>>,
     grammar: Option<Arc<Grammar>>,
     stmt_parse: Option<Arc<StmtParse>>,
+    commands: Option<Arc<Commands>>,
 }
 
 impl Default for Database {
@@ -454,6 +456,7 @@ impl Database {
             outline: None,
             grammar: None,
             stmt_parse: None,
+            commands: None,
             prev_nameset: None,
             prev_scopes: None,
             prev_verify: None,
@@ -823,6 +826,24 @@ impl Database {
             .build_syntax_proof::<usize, Vec<usize>>(&mut vec![], &mut arr);
         arr.calc_indent();
         arr
+    }
+
+    /// Returns the parser commands for this database
+    pub fn commands_pass(&mut self) -> &Arc<Commands> {
+        if self.commands.is_none() {
+            self.name_pass();
+            self.commands = Some(Arc::new(Commands::new(&self.segments, self.name_result())));
+        }
+        self.commands()
+    }
+
+    /// Returns the parser commands for this database
+    /// Requires: [`Database::commands_pass`]
+    #[must_use]
+    pub fn commands(&self) -> &Arc<Commands> {
+        self.commands.as_ref().expect(
+            "The database has not run `commands_pass()`. Please ensure it is run before calling depending methods."
+        )
     }
 
     /// Export the grammar of this database in DOT format.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,8 +57,8 @@ mod segment_set;
 mod tree;
 mod util;
 
-pub mod commands;
 pub mod axiom_use;
+pub mod commands;
 pub mod comment_parser;
 pub mod database;
 pub mod diag;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ mod segment_set;
 mod tree;
 mod util;
 
+pub mod commands;
 pub mod comment_parser;
 pub mod database;
 pub mod diag;


### PR DESCRIPTION
A proposal to move `$j` command interpretation to a lazily evaluated `Commands` struct, as discussed in #103.
Currently only supports the `syntax` command, but more could be added.
`Grammar` can be later refitted to use this struct.