### PR TITLE
add axiom_use generator

### DIFF
--- a/src/axiom_use.rs
+++ b/src/axiom_use.rs
@@ -1,0 +1,43 @@
+//! Generation of the `axiom_use` file.
+use crate::bit_set::Bitset;
+use crate::util::HashMap;
+use crate::StatementType;
+use crate::{as_str, database::time, Database};
+
+impl Database {
+    /// Writes a `axiom_use` file to the given writer.
+    pub fn write_axiom_use(&self, out: &mut impl std::io::Write) -> Result<(), std::io::Error> {
+        time(&self.options.clone(), "axiom_use", || {
+            let mut axiom_use_map = HashMap::default();
+            let mut axioms = vec![];
+            for sref in self.statements().filter(|stmt| stmt.is_assertion()) {
+                let label = sref.label();
+                let mut usage = Bitset::new();
+                if sref.statement_type() == StatementType::Provable {
+                    let mut i = 1;
+                    loop {
+                        let tk = sref.proof_slice_at(i);
+                        i += 1;
+                        if tk == b")" {
+                            break;
+                        }
+                        if let Some(usage2) = axiom_use_map.get(tk) {
+                            usage |= usage2
+                        }
+                    }
+                    write!(out, "{}:", as_str(label))?;
+                    for i in &usage {
+                        write!(out, " {}", axioms[i])?;
+                    }
+                    writeln!(out)?;
+                    axiom_use_map.insert(label, usage);
+                } else if label.starts_with(b"ax-") {
+                    usage.set_bit(axioms.len());
+                    axioms.push(as_str(label));
+                    axiom_use_map.insert(label, usage);
+                }
+            }
+            Ok(())
+        })
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ mod segment_set;
 mod tree;
 mod util;
 
+pub mod axiom_use;
 pub mod comment_parser;
 pub mod database;
 pub mod diag;

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ fn main() {
         (@arg verify: -v --verify "Checks proof validity")
         (@arg verify_markup: -m --("verify-markup") "Checks comment markup")
         (@arg discouraged: -D --discouraged [FILE] "Regenerates `discouraged` file")
+        (@arg axiom_use: -X --("axiom-use") [FILE] "Generate `axiom-use` file")
         (@arg outline: -O --outline "Shows database outline")
         (@arg dump_typesetting: -T --("dump-typesetting") "Dumps typesetting information")
         (@arg parse_typesetting: -t --("parse-typesetting") "Parses typesetting information")
@@ -99,7 +100,7 @@ fn main() {
 
         let mut types = vec![DiagnosticClass::Parse];
 
-        if !matches.is_present("discouraged") {
+        if !matches.is_present("discouraged") && !matches.is_present("axiom_use") {
             types.push(DiagnosticClass::Scope);
         }
 
@@ -129,6 +130,12 @@ fn main() {
         if matches.is_present("discouraged") {
             File::create(matches.value_of("discouraged").unwrap())
                 .and_then(|file| db.write_discouraged(&mut BufWriter::new(file)))
+                .unwrap_or_else(|err| diags.push((StatementAddress::default(), err.into())));
+        }
+
+        if matches.is_present("axiom_use") {
+            File::create(matches.value_of("axiom_use").unwrap())
+                .and_then(|file| db.write_axiom_use(&mut BufWriter::new(file)))
                 .unwrap_or_else(|err| diags.push((StatementAddress::default(), err.into())));
         }
 


### PR DESCRIPTION
Based on a request at https://github.com/metamath/set.mm/issues/3150#issuecomment-1529101901 . This generates a list of the axioms used by every statement in set.mm, like so:
```
a1ii:
idi:
mp2: ax-mp
mp2b: ax-mp
a1i: ax-mp ax-1
2a1i: ax-mp ax-1
mp1i: ax-mp ax-1
a2i: ax-mp ax-2
mpd: ax-mp ax-2
...
```
It takes about 200ms to generate the file.

Some caveats: This is only really designed to work for set.mm. In particular it bakes in two assumptions which are correct for set.mm but not necessarily for other databases:

* It only supports compressed proofs, and will panic on normal mode proofs, and possibly panic or give the wrong result on packed proofs.
* It assumes that axioms are marked with the `ax-` prefix, meaning that definitions are ignored, but also nonstandardly named axioms.