### PR TITLE
always report all errors

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -100,7 +100,6 @@
 use crate::as_str;
 use crate::diag;
 use crate::diag::Diagnostic;
-use crate::diag::DiagnosticClass;
 use crate::export;
 use crate::formula::Formula;
 use crate::formula::Label;
@@ -554,6 +553,17 @@ impl Database {
     }
 
     /// Returns the frames for this database, i.e. the actual logical system.
+    /// Returns `None` if [`Database::scope_pass`] was not previously called.
+    ///
+    /// All logical properties of the database (as opposed to surface syntactic
+    /// properties) can be obtained from this object.
+    #[inline]
+    #[must_use]
+    pub const fn try_scope_result(&self) -> Option<&Arc<ScopeResult>> {
+        self.scopes.as_ref()
+    }
+
+    /// Returns the frames for this database, i.e. the actual logical system.
     /// Panics if [`Database::scope_pass`] was not previously called.
     ///
     /// All logical properties of the database (as opposed to surface syntactic
@@ -561,7 +571,7 @@ impl Database {
     #[inline]
     #[must_use]
     pub fn scope_result(&self) -> &Arc<ScopeResult> {
-        self.scopes.as_ref().expect(
+        self.try_scope_result().expect(
             "The database has not run `scope_pass()`. Please ensure it is run before calling depending methods."
         )
     }
@@ -588,6 +598,17 @@ impl Database {
     }
 
     /// Returns verification information for the database.
+    /// Returns `None` if [`Database::verify_pass`] was not previously called.
+    ///
+    /// This is an optimized verifier which returns no useful information other
+    /// than error diagnostics.  It does not save any parsed proof data.
+    #[inline]
+    #[must_use]
+    pub const fn try_verify_result(&self) -> Option<&Arc<VerifyResult>> {
+        self.verify.as_ref()
+    }
+
+    /// Returns verification information for the database.
     /// Panics if [`Database::verify_pass`] was not previously called.
     ///
     /// This is an optimized verifier which returns no useful information other
@@ -595,7 +616,7 @@ impl Database {
     #[inline]
     #[must_use]
     pub fn verify_result(&self) -> &Arc<VerifyResult> {
-        self.verify.as_ref().expect(
+        self.try_verify_result().expect(
             "The database has not run `verify_pass()`. Please ensure it is run before calling depending methods."
         )
     }
@@ -612,11 +633,19 @@ impl Database {
     }
 
     /// Returns the typesetting data.
+    /// Returns `None` if [`Database::typesetting_pass`] was not previously called.
+    #[inline]
+    #[must_use]
+    pub const fn try_typesetting_result(&self) -> Option<&Arc<TypesettingData>> {
+        self.typesetting.as_ref()
+    }
+
+    /// Returns the typesetting data.
     /// Panics if [`Database::typesetting_pass`] was not previously called.
     #[inline]
     #[must_use]
     pub fn typesetting_result(&self) -> &Arc<TypesettingData> {
-        self.typesetting.as_ref().expect(
+        self.try_typesetting_result().expect(
             "The database has not run `typesetting_pass()`. Please ensure it is run before calling depending methods."
         )
     }
@@ -636,8 +665,16 @@ impl Database {
     /// Panics if [`Database::outline_pass`] was not previously called.
     #[inline]
     #[must_use]
+    pub const fn try_outline_result(&self) -> Option<&Arc<Outline>> {
+        self.outline.as_ref()
+    }
+
+    /// Returns the root node of the outline.
+    /// Panics if [`Database::outline_pass`] was not previously called.
+    #[inline]
+    #[must_use]
     pub fn outline_result(&self) -> &Arc<Outline> {
-        self.outline.as_ref().expect(
+        self.try_outline_result().expect(
             "The database has not run `outline_pass()`. Please ensure it is run before calling depending methods."
         )
     }
@@ -655,11 +692,19 @@ impl Database {
     }
 
     /// Returns the grammar.
+    /// Returns `None` if [`Database::grammar_pass`] was not previously called.
+    #[inline]
+    #[must_use]
+    pub const fn try_grammar_result(&self) -> Option<&Arc<Grammar>> {
+        self.grammar.as_ref()
+    }
+
+    /// Returns the grammar.
     /// Panics if [`Database::grammar_pass`] was not previously called.
     #[inline]
     #[must_use]
     pub fn grammar_result(&self) -> &Arc<Grammar> {
-        self.grammar.as_ref().expect(
+        self.try_grammar_result().expect(
             "The database has not run `grammar_pass()`. Please ensure it is run before calling depending methods."
         )
     }
@@ -683,11 +728,19 @@ impl Database {
     }
 
     /// Returns the statements parsed using the grammar.
+    /// Returns `None` if [`Database::stmt_parse_pass`] was not previously called.
+    #[inline]
+    #[must_use]
+    pub const fn try_stmt_parse_result(&self) -> Option<&Arc<StmtParse>> {
+        self.stmt_parse.as_ref()
+    }
+
+    /// Returns the statements parsed using the grammar.
     /// Panics if [`Database::stmt_parse_pass`] was not previously called.
     #[inline]
     #[must_use]
     pub fn stmt_parse_result(&self) -> &Arc<StmtParse> {
-        self.stmt_parse.as_ref().expect(
+        self.try_stmt_parse_result().expect(
             "The database has not run `stmt_parse_pass()`. Please ensure it is run before calling depending methods."
         )
     }
@@ -896,34 +949,24 @@ impl Database {
 
     /// Collects and returns all errors generated by the passes run.
     ///
-    /// Passes are identified by the `types` argument and are not inclusive; if
-    /// you ask for Verify, you will not get Parse unless you specifically ask
-    /// for that as well.
-    ///
     /// Currently there is no way to incrementally fetch diagnostics, so this
     /// will be a bit slow if there are thousands of errors.
-    pub fn diag_notations(
-        &mut self,
-        types: &[DiagnosticClass],
-    ) -> Vec<(StatementAddress, Diagnostic)> {
-        let mut diags = Vec::new();
-        if types.contains(&DiagnosticClass::Parse) {
-            diags.extend(self.parse_result().parse_diagnostics());
+    pub fn diag_notations(&mut self) -> Vec<(StatementAddress, Diagnostic)> {
+        let mut diags = self.parse_result().parse_diagnostics();
+        if let Some(pass) = self.try_scope_result() {
+            diags.extend(pass.diagnostics())
         }
-        if types.contains(&DiagnosticClass::Scope) {
-            diags.extend(self.scope_pass().diagnostics());
+        if let Some(pass) = self.try_verify_result() {
+            diags.extend(pass.diagnostics())
         }
-        if types.contains(&DiagnosticClass::Verify) {
-            diags.extend(self.verify_pass().diagnostics());
+        if let Some(pass) = self.try_grammar_result() {
+            diags.extend(pass.diagnostics())
         }
-        if types.contains(&DiagnosticClass::Grammar) {
-            diags.extend(self.grammar_pass().diagnostics());
+        if let Some(pass) = self.try_stmt_parse_result() {
+            diags.extend(pass.diagnostics())
         }
-        if types.contains(&DiagnosticClass::StmtParse) {
-            diags.extend(self.stmt_parse_pass().diagnostics());
-        }
-        if types.contains(&DiagnosticClass::Typesetting) {
-            diags.extend(self.typesetting_pass().diagnostics.iter().cloned());
+        if let Some(pass) = self.try_typesetting_result() {
+            diags.extend_from_slice(&pass.diagnostics)
         }
         diags
     }

--- a/src/diag.rs
+++ b/src/diag.rs
@@ -30,27 +30,6 @@ use std::fmt::Display;
 use std::io;
 use typed_arena::Arena;
 
-/// List of passes that generate diagnostics, for use with the
-/// `Database::diag_notations` filter.
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
-pub enum DiagnosticClass {
-    /// Parse errors, which can be observed from a single statement in
-    /// isolation.
-    Parse,
-    /// Scope errors are mostly inter-statement consistency checks which
-    /// invalidate the logical interpretation of a statement.
-    Scope,
-    /// Verify errors do not invalidate the interpretation of statements, but
-    /// affect only proofs.
-    Verify,
-    /// Grammar errors reflect whether the database is unambiguous
-    Grammar,
-    /// Statement Parsing result
-    StmtParse,
-    /// $t statement parsing result
-    Typesetting,
-}
-
 /// The three kinds of markup supported by `$t` typesetting comments.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum MarkupKind {

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,10 +97,6 @@ fn main() {
     loop {
         db.parse(start.clone(), data.clone());
 
-        if !matches.is_present("discouraged") {
-            db.scope_pass();
-        }
-
         if matches.is_present("verify") {
             db.verify_pass();
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@
 use annotate_snippets::display_list::DisplayList;
 use clap::{clap_app, crate_version};
 use metamath_knife::database::{Database, DbOptions};
-use metamath_knife::diag::{BibError, DiagnosticClass};
+use metamath_knife::diag::BibError;
 use metamath_knife::statement::StatementAddress;
 use metamath_knife::verify_markup::{Bibliography, Bibliography2};
 use metamath_knife::SourceInfo;
@@ -97,26 +97,24 @@ fn main() {
     loop {
         db.parse(start.clone(), data.clone());
 
-        let mut types = vec![DiagnosticClass::Parse];
-
         if !matches.is_present("discouraged") {
-            types.push(DiagnosticClass::Scope);
+            db.scope_pass();
         }
 
         if matches.is_present("verify") {
-            types.push(DiagnosticClass::Verify);
+            db.verify_pass();
         }
 
         if matches.is_present("grammar") {
-            types.push(DiagnosticClass::Grammar);
+            db.grammar_pass();
         }
 
         if matches.is_present("parse_stmt") {
-            types.push(DiagnosticClass::StmtParse);
+            db.stmt_parse_pass();
         }
 
         if matches.is_present("parse_typesetting") {
-            types.push(DiagnosticClass::Typesetting);
+            db.typesetting_pass();
         }
 
         if matches.is_present("verify_parse_stmt") {
@@ -124,7 +122,7 @@ fn main() {
             db.verify_parse_stmt();
         }
 
-        let mut diags = db.diag_notations(&types);
+        let mut diags = db.diag_notations();
 
         if matches.is_present("discouraged") {
             File::create(matches.value_of("discouraged").unwrap())


### PR DESCRIPTION
As pointed out in https://github.com/david-a-wheeler/metamath-knife/pull/107#discussion_r1181545930, if you use the command line options to e.g. enable the verify pass but not the scope pass, the errors from the scope pass will not be reported (and this could potentially make the program report no errors and give an OK error code even though there were errors).

In this PR we simplify the interface to eliminate the `DiagnosticClass` enum to filter error results and always report errors from all passes that have been run (and by selecting different options you change which passes run).