### PR TITLE
Fixing the running of export statements

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -194,6 +194,8 @@ fn main() {
         }
 
         if let Some(exps) = matches.values_of_lossy("export") {
+            db.name_pass();
+            db.scope_pass();
             for file in exps {
                 db.export(&file);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -194,7 +194,6 @@ fn main() {
         }
 
         if let Some(exps) = matches.values_of_lossy("export") {
-            db.name_pass();
             db.scope_pass();
             for file in exps {
                 db.export(&file);


### PR DESCRIPTION
When I was trying to run an export statement, I was getting:
```

0 diagnostics issued.
thread 'main' panicked at 'The database has not run `name_pass()`. Please ensure it is run before calling depending methods.', src/database.rs:530:31
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This PR fixes it. 

Discussion:
If you want to make a helper function that calls name_pass and scope_pass, I am happy to provide it. 

Testplan:
run an export command like:
```
cargo run ~/Downloads/metamath/set.mm --export fzval
```
and see that it runs through.