### PR TITLE
Add function to export theorem dependencies in GraphML format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,7 @@ dependencies = [
  "simple_logger",
  "tinyvec",
  "typed-arena",
+ "xml-rs",
 ]
 
 [[package]]
@@ -384,6 +385,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "xml-rs"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52839dc911083a8ef63efa4d039d1f58b5e409f923e44c80828f206f66e5541c"
 
 [[package]]
 name = "yansi-term"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,12 @@ simple_logger = "1.13"
 
 # Optional dependencies
 dot-writer = { version = "0.1.2", optional = true }
+xml-rs = { version = "0.8.14", optional = true }
 
 [features]
 default = ["annotate-snippets/color"]
 dot = ["dot-writer"]
+xml = ["xml-rs"]
 
 [profile]
 

--- a/src/export_deps.rs
+++ b/src/export_deps.rs
@@ -1,0 +1,56 @@
+//! Generation of a `GraphML` file containing all theorem dependencies.
+
+use crate::StatementType;
+use crate::{as_str, database::time, Database};
+use xml::writer::{EmitterConfig, XmlEvent};
+
+use crate::diag::Diagnostic;
+
+impl From<xml::writer::Error> for Diagnostic {
+    fn from(err: xml::writer::Error) -> Diagnostic {
+        Diagnostic::IoError(format!("{err}"))
+    }
+}
+
+impl Database {
+    /// Writes down all dependencies in a `GraphML` file format to the given writer.
+    pub fn export_graphml_deps(&self, out: &mut impl std::io::Write) -> Result<(), Diagnostic> {
+        time(&self.options.clone(), "export_graphml_deps", || {
+            let mut writer = EmitterConfig::new().perform_indent(true).create_writer(out);
+            writer.write(
+                XmlEvent::start_element("graphml")
+                    .attr("xmlns", "http://graphml.graphdrawing.org/xmlns")
+                    .attr("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance")
+                    .attr(
+                        "xsi:schemaLocation",
+                        "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd",
+                    ),
+            )?;
+            writer.write(XmlEvent::start_element("grpah").attr("id", "dependencies"))?;
+            for sref in self.statements().filter(|stmt| stmt.is_assertion()) {
+                let label = sref.label();
+                writer.write(XmlEvent::start_element("node").attr("id", as_str(label)))?;
+                writer.write(XmlEvent::end_element())?; // node
+                if sref.statement_type() == StatementType::Provable {
+                    let mut i = 1;
+                    loop {
+                        let tk = sref.proof_slice_at(i);
+                        i += 1;
+                        if tk == b")" {
+                            break;
+                        }
+                        writer.write(
+                            XmlEvent::start_element("edge")
+                                .attr("source", as_str(label))
+                                .attr("target", as_str(tk)),
+                        )?;
+                        writer.write(XmlEvent::end_element())?;
+                    }
+                }
+            }
+            writer.write(XmlEvent::end_element())?; // graph
+            writer.write(XmlEvent::end_element())?; // graphml
+            Ok(())
+        })
+    }
+}

--- a/src/export_deps.rs
+++ b/src/export_deps.rs
@@ -26,7 +26,7 @@ impl Database {
                         "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd",
                     ),
             )?;
-            writer.write(XmlEvent::start_element("grpah").attr("id", "dependencies"))?;
+            writer.write(XmlEvent::start_element("graph").attr("id", "dependencies"))?;
             for sref in self.statements().filter(|stmt| stmt.is_assertion()) {
                 let label = sref.label();
                 writer.write(XmlEvent::start_element("node").attr("id", as_str(label)))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,9 @@ pub mod typesetting;
 pub mod verify;
 pub mod verify_markup;
 
+#[cfg(feature = "xml")]
+pub mod export_deps;
+
 #[cfg(test)]
 mod comment_parser_tests;
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,12 @@ fn main() {
             "Export the database's grammar in Graphviz DOT format for visualization")
     );
 
+    #[cfg(feature = "xml")]
+    let app = clap_app!(@app (app)
+        (@arg export_graphml_deps: --("export-graphml-deps") [FILE]
+        "Exports all theorem dependencies in the GraphML file format")
+    );
+
     let matches = app.get_matches();
 
     let options = DbOptions {
@@ -124,6 +130,14 @@ fn main() {
             File::create(matches.value_of("discouraged").unwrap())
                 .and_then(|file| db.write_discouraged(&mut BufWriter::new(file)))
                 .unwrap_or_else(|err| diags.push((StatementAddress::default(), err.into())));
+        }
+
+        #[cfg(feature = "xml")]
+        if matches.is_present("export_graphml_deps") {
+            File::create(matches.value_of("export_graphml_deps").unwrap())
+                .map_err(|err| err.into())
+                .and_then(|file| db.export_graphml_deps(&mut BufWriter::new(file)))
+                .unwrap_or_else(|diag| diags.push((StatementAddress::default(), diag)));
         }
 
         let mut count = db

--- a/src/util_tests.rs
+++ b/src/util_tests.rs
@@ -40,7 +40,7 @@ fn test_copy_portion() {
 
 #[test]
 #[should_panic(expected = "out of range")]
-// #[allow(clippy::collection_is_never_read)]
+#[allow(clippy::collection_is_never_read)]
 fn test_copy_portion_oob() {
     let mut s = Vec::from(b"Hello world" as &[u8]);
     s.extend_from_within(11..12);


### PR DESCRIPTION
As per discussion on the google groups:

This adds a new option `--export-graphml-deps [FILE]` (no shortcut), which allows to export the theorem dependencies in [GraphML](http://graphml.graphdrawing.org/) format.
Requires to be compiled with the `xml` feature.