### PR TITLE
Axiom usage verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,6 +168,7 @@ name = "metamath-knife"
 version = "0.3.6"
 dependencies = [
  "annotate-snippets",
+ "assert_matches",
  "clap",
  "dot-writer",
  "filetime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ simple_logger = "1.13"
 dot-writer = { version = "0.1.2", optional = true }
 xml-rs = { version = "0.8.14", optional = true }
 
+[dev-dependencies]
+assert_matches = "1.5"
+
 [features]
 default = ["annotate-snippets/color"]
 dot = ["dot-writer"]

--- a/src/axiom_use.rs
+++ b/src/axiom_use.rs
@@ -18,7 +18,7 @@ use crate::{as_str, database::time, Database};
 pub struct UsageResult(Vec<(StatementAddress, Diagnostic)>);
 
 impl UsageResult {
-    /// Returns the list of errors that were generated during the definition check pass.
+    /// Returns the list of errors that were generated during the usage check pass.
     #[must_use]
     pub fn diagnostics(&self) -> Vec<(StatementAddress, Diagnostic)> {
         self.0.clone()

--- a/src/axiom_use.rs
+++ b/src/axiom_use.rs
@@ -1,8 +1,136 @@
 //! Generation of the `axiom_use` file.
+use std::sync::Arc;
+
+use itertools::PeekingNext;
+
 use crate::bit_set::Bitset;
+use crate::diag::Diagnostic;
+use crate::segment::SegmentRef;
+use crate::segment_set::SegmentSet;
+use crate::statement::{CommandToken, StatementAddress, TokenPtr};
 use crate::util::HashMap;
 use crate::StatementType;
 use crate::{as_str, database::time, Database};
+
+/// Diagnostics issued when checking axiom usage in the Database.
+///
+#[derive(Debug, Default)]
+pub struct UsageResult(Vec<(StatementAddress, Diagnostic)>);
+
+impl UsageResult {
+    /// Returns the list of errors that were generated during the definition check pass.
+    #[must_use]
+    pub fn diagnostics(&self) -> Vec<(StatementAddress, Diagnostic)> {
+        self.0.clone()
+    }
+}
+
+struct UsagePass<'a> {
+    axiom_use_map: HashMap<TokenPtr<'a>, Bitset>,
+    axioms: Vec<TokenPtr<'a>>,
+    result: &'a mut UsageResult,
+}
+
+impl<'a> UsagePass<'a> {
+    // Parses the 'usage' commmands in the database,
+    fn parse_command(
+        &mut self,
+        sref: SegmentRef<'_>,
+        args: &[CommandToken],
+    ) -> Result<(), Vec<Diagnostic>> {
+        use CommandToken::*;
+        let buf = &**sref.buffer;
+        match args {
+            [Keyword(cmd), label, Keyword(avoids), ..]
+                if cmd.as_ref(buf) == b"usage" && avoids.as_ref(buf) == b"avoids" =>
+            {
+                let stmt = label.value(buf);
+                let usage = self
+                    .axiom_use_map
+                    .get(stmt)
+                    .ok_or_else(|| vec![Diagnostic::UnknownLabel(label.full_span())])?;
+                let mut diags = vec![];
+                for cmd in &args[3..] {
+                    let axiom = cmd.value(buf);
+                    if let Some(index) = self.axioms.iter().position(|&x| x == axiom) {
+                        if usage.has_bit(index) {
+                            // TODO possibly research the usage "path" leading to this error.
+                            diags.push(Diagnostic::UsageViolation(
+                                cmd.full_span(),
+                                stmt.into(),
+                                axiom.into(),
+                            ));
+                        }
+                    } else {
+                        diags.push(Diagnostic::UnknownLabel(cmd.full_span()));
+                    }
+                }
+                Err(diags)
+            }
+            _ => Ok(()),
+        }
+    }
+
+    /// Verify that all usage declarations are correct.
+    fn verify_usage(&'a mut self, sset: &'a SegmentSet) {
+        for sref in sset.segments(..) {
+            let mut j_commands: std::slice::Iter<'_, (i32, (crate::Span, Vec<CommandToken>))> =
+                sref.j_commands.iter();
+            for stmt in sref.range(..) {
+                match stmt.statement_type() {
+                    StatementType::AdditionalInfoComment => {
+                        eprintln!("$j!");
+                        while let Some(&(_, (_, ref args))) =
+                            j_commands.peeking_next(|i| i.0 == stmt.index)
+                        {
+                            if let Err(diags) = self.parse_command(sref, args) {
+                                for diag in diags {
+                                    self.result.0.push((stmt.address(), diag));
+                                }
+                            }
+                        }
+                    }
+                    StatementType::Provable => {
+                        let label = stmt.label();
+                        let mut usage = Bitset::new();
+                        let mut i = 1;
+                        loop {
+                            let tk = stmt.proof_slice_at(i);
+                            i += 1;
+                            if tk == b")" {
+                                break;
+                            }
+                            if let Some(usage2) = self.axiom_use_map.get(tk) {
+                                usage |= usage2
+                            }
+                        }
+                        self.axiom_use_map.insert(label, usage);
+                    }
+                    StatementType::Axiom => {
+                        let label = stmt.label();
+                        if label.starts_with(b"ax-") {
+                            let mut usage = Bitset::new();
+                            usage.set_bit(self.axioms.len());
+                            self.axioms.push(label);
+                            self.axiom_use_map.insert(label, usage);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+}
+
+/// Verify the axiom usage
+pub(crate) fn verify_usage(sset: &Arc<SegmentSet>, usage: &mut UsageResult) {
+    UsagePass {
+        axiom_use_map: HashMap::default(),
+        axioms: vec![],
+        result: usage,
+    }
+    .verify_usage(sset);
+}
 
 impl Database {
     /// Writes a `axiom_use` file to the given writer.

--- a/src/axiom_use.rs
+++ b/src/axiom_use.rs
@@ -105,7 +105,6 @@ impl<'a> UsagePass<'a> {
                             }
                         }
                         self.axiom_use_map.insert(label, usage);
-                        eprintln!("Done");
                     }
                     StatementType::Axiom => {
                         let label = stmt.label();

--- a/src/diag.rs
+++ b/src/diag.rs
@@ -198,6 +198,7 @@ pub enum Diagnostic {
     UnknownKeyword(Span),
     UnknownTypesettingCommand(Span),
     UnmatchedCloseGroup,
+    UsageViolation(Span, Token, Token),
     VariableMissingFloat(TokenIndex),
     VariableRedeclaredAsConstant(TokenIndex, TokenAddress),
     WindowsReservedLabel(Span),
@@ -1133,6 +1134,12 @@ impl Diagnostic {
                 "This $} does not match any open ${".into(),
                 stmt,
                 stmt.span(),
+            )]),
+            UsageViolation(span, label, axiom) => ("Usage violation".into(), vec![(
+                AnnotationType::Warning,
+                format!("Statement {label} uses axiom {axiom} despite $j declaring it avoids its usage.", label=as_str(label), axiom=as_str(axiom)).into(),
+                stmt,
+                *span,
             )]),
             VariableMissingFloat(index) => ("Variable missing float".into(), vec![(
                 AnnotationType::Error,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,8 @@ mod grammar_tests;
 #[cfg(test)]
 mod parser_tests;
 #[cfg(test)]
+mod usage_tests;
+#[cfg(test)]
 mod util_tests;
 
 pub use database::Database;

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ fn main() {
         (@arg verify_markup: -m --("verify-markup") "Checks comment markup")
         (@arg discouraged: -D --discouraged [FILE] "Regenerates `discouraged` file")
         (@arg axiom_use: -X --("axiom-use") [FILE] "Generate `axiom-use` file")
+        (@arg verify_usage: -u --("verify-usage") "Checks axiom usage")
         (@arg outline: -O --outline "Shows database outline")
         (@arg dump_typesetting: -T --("dump-typesetting") "Dumps typesetting information")
         (@arg parse_typesetting: -t --("parse-typesetting") "Parses typesetting information")
@@ -123,6 +124,10 @@ fn main() {
         if matches.is_present("verify_parse_stmt") {
             db.stmt_parse_pass();
             db.verify_parse_stmt();
+        }
+
+        if matches.is_present("verify_usage") {
+            db.verify_usage_pass();
         }
 
         let mut diags = db.diag_notations();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -681,7 +681,10 @@ fn collect_definitions(seg: &mut Segment) {
                     });
                 }
             }
-            continue;
+            // Skip further treatment if the statement is not at top-level, except for $j commands.
+            if stmt.stype != AdditionalInfoComment {
+                continue;
+            }
         }
 
         let math = &seg.span_pool[stmt.math_start..stmt.proof_start];

--- a/src/usage_tests.rs
+++ b/src/usage_tests.rs
@@ -1,0 +1,25 @@
+use crate::diag::Diagnostic::UsageViolation;
+use crate::grammar_tests::mkdb;
+use assert_matches::assert_matches;
+
+const USAGE_DB: &[u8] = b"
+$c wff |- > $.  $v a $.
+wa $f |- a $.
+ax-1 $a |- > a $.
+thm1 $p |- > a $= wa ax-1 $.
+$( $j usage 'thm1' avoids 'ax-1'; $)
+thm2 $p |- > a $= ( ax-1 ) AB $.
+$( $j usage 'thm2' avoids 'ax-1'; $)
+";
+
+#[test]
+fn test_usage() {
+    let mut db = mkdb(USAGE_DB);
+    assert_eq!(db.parse_result().parse_diagnostics(), vec![]);
+    let usage = db.verify_usage_pass();
+    let diags = usage.diagnostics();
+
+    assert_eq!(diags.len(), 2);
+    assert_matches!(diags[0], (_, UsageViolation(..)));
+    assert_matches!(diags[1], (_, UsageViolation(..)));
+}


### PR DESCRIPTION
Naive but functional axiom usage check.

Introduces a `-u` option which checks that `$j usage 'xxx' avoids 'yyy'` commands are respected.

This only checks axioms dependencies, not all statements.
Currently issues an "Unknown label" diagnostic if the axiom declared as avoided actually only declared further down in the database. This is the simpler implementation, but this generates many warnings with the current `set.mm`.