### PR TITLE
Fix: Reject invalid characters in compressed proofs

### DIFF
--- a/metamath-rs/src/verify.rs
+++ b/metamath-rs/src/verify.rs
@@ -722,6 +722,10 @@ fn verify_proof<'a, P: ProofBuilder>(
                 } else if ch == b'?' {
                     try_assert!(k == 0, Diagnostic::ProofMalformedVarint);
                     return Err(Diagnostic::ProofIncomplete);
+                } else {
+                    // Reject invalid characters (digits, lowercase, punctuation, etc.)
+                    // Valid compressed proof chars per Appendix B: A-Z and ?
+                    return Err(Diagnostic::ProofMalformedVarint);
                 }
             }
             i += 1;

--- a/metamath-rs/src/verify.rs
+++ b/metamath-rs/src/verify.rs
@@ -723,8 +723,6 @@ fn verify_proof<'a, P: ProofBuilder>(
                     try_assert!(k == 0, Diagnostic::ProofMalformedVarint);
                     return Err(Diagnostic::ProofIncomplete);
                 } else {
-                    // Reject invalid characters (digits, lowercase, punctuation, etc.)
-                    // Valid compressed proof chars per Appendix B: A-Z and ?
                     return Err(Diagnostic::ProofMalformedVarint);
                 }
             }


### PR DESCRIPTION
metamath-knife seems to have been missing a check for invalid characters (such as '0') in compressed proofs.  Claude Code added an else for this.

It was caught on this test.

```
$( Unit Test 19: Illegal characters in compressed proof $)
$( Should reject: True $)

$c wff |- $.
$v x $.
wf $f wff x $.
ax $a |- x $.
th $p |- x $= ( ax ) A0B $.
```
